### PR TITLE
Close three silent-pass gaps and cut v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Fails fast, before tests or build spend time: the unit suite ties README.md
+      # to CHANGELOG.md but cannot see the tag, so both files can agree at one version
+      # while the release is tagged at another and every test stays green. stdlib-only,
+      # so it needs no uv setup and runs first.
+      - name: Check release version matches README and CHANGELOG
+        run: python3 skill/check_release_version.py "${{ github.ref_name }}"
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,27 @@ jobs:
 
       - name: Build and test
         run: bash skill/run-tests.sh
+
+  # The unit suite never imports anthropic or deepeval -- executor.py imports anthropic
+  # lazily inside a function, and test_evals.py is excluded from the default run -- so a
+  # dependency upgrade can break the eval harness with every test still green (issue #122).
+  # This job installs the eval extra and exercises the harness's third-party surface. It
+  # makes no API calls and needs no secret, so it runs on every push and pull request.
+  eval-imports:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install eval dependencies
+        run: uv sync --locked --extra test --extra eval
+        working-directory: skill
+
+      - name: Eval harness import smoke test
+        run: uv run --locked python -m pytest tests/test_eval_imports.py -v
+        working-directory: skill

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: skill
 
       - name: Type check (mypy)
-        run: uv run mypy eval tests build.py
+        run: uv run mypy eval tests build.py check_release_version.py
         working-directory: skill
 
       - name: Build and test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # PDCA Framework Skill - Update Summary
 
-## Unreleased
+## v1.3.0 (2026-08-18)
+
+> **Windows builders:** `build-skill.ps1` now requires a Python 3 interpreter on `PATH` as
+> `python3` or `python`. It is a thin wrapper over `build.py` and no longer carries its own
+> PowerShell implementation of the build. The published `.skill` package is unaffected — this
+> matters only if you build from source on Windows.
 
 ### Build system — shared `build.py` extraction (#114)
 
@@ -30,6 +35,55 @@
   gracefully for contributors without PowerShell installed.
 - `mypy` coverage widened from `eval tests` to `eval tests build.py` so the new module is
   type-checked in CI.
+
+### Dependencies — lockfile corrected and pinned (#113)
+
+- **`skill/uv.lock` could not satisfy `skill/pyproject.toml`.** Five declared floors were
+  violated at once: `anthropic` 0.99.0 against `>=0.120.2`, `deepeval` 3.9.9 against `>=4.1.4`,
+  `mypy` 1.20.2 against `>=2.3.0`, `pytest` 9.0.3 against `>=9.1.1`, and `ruff` 0.15.12 against
+  `>=0.16.0`. Every `uv run` therefore re-resolved and rewrote the lockfile, leaving a ~450-line
+  dependency diff in the working tree of anyone who ran the test suite — and a routine
+  `git commit -a` would sweep a dependency upgrade into an unrelated change.
+- Relocked deliberately as its own commit, and `run-tests.sh` now uses `uv run --locked` so
+  future drift is a hard failure rather than a silent rewrite. Deliberately *not* `--frozen`,
+  which stops the churn by skipping the staleness check entirely — that would have hidden the
+  condition permanently instead of fixing it.
+
+### Repository hygiene — gates that could not fail
+
+Several checks in this repo reported green without ever having been capable of failing. Each is
+now backed by a mechanism:
+
+- **`run-tests.sh` never provisioned its own venv (#89).** It called `uv run` and relied on
+  something else having synced the extras — which both CI workflows do, which is why the script
+  was never observed running unprovisioned. On a fresh clone it fails with `No module named
+  pytest`; worse, where an ambient `ruff` exists on `PATH` the lint gate reports green while
+  running a version *below* the floor `pyproject.toml` declares. The script now syncs
+  `--extra test --extra lint` itself, so local and CI runs provision identically.
+- **The release checklist's "update `skill/README.md`" step had nothing behind it.** It was
+  skipped at v1.2.0 and nothing failed. `TestReadme::test_current_version_matches_changelog` now
+  ties the README's version to the newest released `CHANGELOG.md` heading.
+- **A matching README and CHANGELOG can still disagree with the tag**, and no unit test can see
+  a tag. `skill/check_release_version.py` runs in the release workflow against
+  `github.ref_name` and reports every disagreement between the tag and both files in one pass.
+- **Nothing exercised the eval harness's third-party surface (#122).** `eval/executor.py`
+  imports `anthropic` lazily and `tests/test_evals.py` is excluded from the default run, so the
+  `deepeval` major-version bump above could have broken the harness with every test still green.
+  `tests/test_eval_imports.py` constructs `AnthropicModel`, `GEval`, and `LLMTestCase` — no API
+  calls, no secret — run by a dedicated `eval-imports` CI job. It is not skip-guarded: a skipped
+  smoke test is indistinguishable from a passing one.
+
+### Documentation
+
+- **`BUILD.md` carried the same `skill/src` assumption that caused #114**, instructing
+  maintainers to edit `build-skill.sh` and `build-skill.ps1` separately for master paths and
+  packaging. Rewritten against the real tree, with a new Architecture section covering the
+  pinned `build(skill_dir) -> Path` interface and the stale-artifact masking hazard.
+- **`AGENTS.md` described a `skill/src/core/` layout** that has not existed since the rename,
+  and carried a "⚠️ Dual build scripts — update BOTH" warning instructing exactly the practice
+  that caused #114.
+- `BUILD.md`'s Git Strategy recommended committing generated files while `.gitignore` ignores
+  them; stale `pdca-code-generation-process` links, which 404, now point at the current repo.
 
 ### Eval harness — mechanical matching repair
 

--- a/skill/README.md
+++ b/skill/README.md
@@ -502,7 +502,7 @@ Help improve the framework:
 
 ## Version Information
 
-**Current Version:** v1.2.0
+**Current Version:** v1.3.0
 **License:** CC BY 4.0 (documentation & prompts) / MIT (source code)
 **Attribution:** Ken Judy with Claude Anthropic 4
 **Last Updated:** 2026-05-28

--- a/skill/check_release_version.py
+++ b/skill/check_release_version.py
@@ -1,0 +1,97 @@
+"""Verify a release tag agrees with README.md and CHANGELOG.md before publishing.
+
+`tests/test_build.py::TestReadme::test_current_version_matches_changelog` ties the two
+files to each other, which catches the drift that actually happened at v1.2.0 (the
+release checklist's "update skill/README.md" step was skipped and nothing failed).
+It cannot catch a third case: both files agreeing at one version while the release is
+tagged at another. At unit-test time there is no tag to compare against.
+
+The release workflow has one -- `github.ref_name` -- so the check lives here and runs
+there, with the tag passed in. Every disagreement is reported in a single run, so a
+maintainer fixes them all at once rather than discovering the next one by re-tagging.
+
+    python3 check_release_version.py v1.3.0
+
+Exits 0 when consistent, 1 otherwise, printing each problem to stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+README_VERSION = re.compile(r"\*\*Current Version:\*\*\s*v?(\d+\.\d+\.\d+)")
+
+# Anchored at line start and requiring "v" plus a dotted triple, so "## Unreleased" and
+# prose headings like "## What Changed" cannot be mistaken for the newest release.
+CHANGELOG_RELEASE = re.compile(r"^## v(\d+\.\d+\.\d+)", re.MULTILINE)
+
+
+def _normalize(tag: str) -> str:
+    """Drop a leading 'v' so 'v1.3.0' and '1.3.0' compare equal."""
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def check_release_version(tag: str, repo_root: Path) -> list[str]:
+    """Return every disagreement between `tag`, README.md, and CHANGELOG.md.
+
+    An empty list means the three agree and the release is safe to publish.
+    """
+    version = _normalize(tag)
+    problems: list[str] = []
+
+    readme_path = repo_root / "skill" / "README.md"
+    if not readme_path.is_file():
+        problems.append(f"README not found at {readme_path}")
+    else:
+        match = README_VERSION.search(readme_path.read_text())
+        if match is None:
+            problems.append(
+                f"{readme_path} has no '**Current Version:** vX.Y.Z' line to check against tag {tag}"
+            )
+        elif match.group(1) != version:
+            problems.append(
+                f"README says v{match.group(1)} but the release is tagged {tag} -- "
+                "update skill/README.md's '**Current Version:**' line"
+            )
+
+    changelog_path = repo_root / "CHANGELOG.md"
+    if not changelog_path.is_file():
+        problems.append(f"CHANGELOG not found at {changelog_path}")
+    else:
+        match = CHANGELOG_RELEASE.search(changelog_path.read_text())
+        if match is None:
+            problems.append(
+                f"{changelog_path} has no '## vX.Y.Z' released-version heading to check against tag {tag}"
+            )
+        elif match.group(1) != version:
+            problems.append(
+                f"CHANGELOG's newest released heading is v{match.group(1)} but the release is "
+                f"tagged {tag} -- promote the '## Unreleased' section to '## v{version}' before tagging"
+            )
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0] if argv else 'check_release_version.py'} <tag>", file=sys.stderr)
+        return 2
+
+    # This file lives in skill/, so the repo root is its parent's parent.
+    repo_root = Path(__file__).resolve().parent.parent
+    problems = check_release_version(argv[1], repo_root)
+
+    if problems:
+        print(f"Release version check failed for tag {argv[1]}:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"Release version check passed: tag {argv[1]} agrees with README.md and CHANGELOG.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -38,7 +38,11 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--ignore=tests/test_evals.py"
+# test_evals.py makes real API calls; test_eval_imports.py needs the `eval` extra, which
+# the default `test`/`lint` sync does not install. Both are excluded here and run by their
+# own means -- run-evals.sh and the eval-imports CI job respectively -- rather than being
+# guarded by in-test skips, which would be indistinguishable from passing.
+addopts = "--ignore=tests/test_evals.py --ignore=tests/test_eval_imports.py"
 markers = [
     "eval: marks tests as LLM evaluation tests (require ANTHROPIC_API_KEY, incur API costs — run with: uv run ./run-evals.sh)",
 ]

--- a/skill/run-tests.sh
+++ b/skill/run-tests.sh
@@ -27,6 +27,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 WARN_ONLY="${WARN_ONLY:-0}"
 
+# Provision the venv this script's own tools live in (issue #89). Without this,
+# `uv run` auto-creates a venv containing only the project package -- ruff and
+# pytest are in optional extras it does not install. On a fresh clone that fails
+# outright; worse, if an ambient ruff exists on PATH, `uv run ruff` silently uses
+# it and the lint gate reports green while running a version below the floor
+# pyproject.toml declares. CI never caught either, because its workflows sync the
+# extras before calling this script -- so the script only ever ran pre-provisioned.
+# Syncing here makes it self-contained and identical in both places.
+echo "=== Syncing dependencies ==="
+(cd "$SCRIPT_DIR" && uv sync --locked --extra test --extra lint)
+
+echo ""
 echo "=== Building PDCA Framework Skill ==="
 bash "$SCRIPT_DIR/build-skill.sh"
 

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -278,6 +278,31 @@ class TestProjectSetup(unittest.TestCase):
             "run-tests.sh must invoke 'uv run pytest', not bare 'python3'",
         )
 
+    def test_run_tests_script_syncs_its_own_dependencies(self):
+        """run-tests.sh must install the test and lint extras, not assume a provisioned venv.
+
+        Issue #89. `uv run` auto-creates a venv holding only the project package —
+        ruff and pytest live in optional extras it does not install. That fails outright
+        on a fresh clone, and fails worse when an ambient ruff exists on PATH: the lint
+        gate reports green while running a version below pyproject.toml's own declared
+        floor. CI never caught either because its workflows sync the extras first.
+        """
+        script = (CLAUDE_SKILL_DIR / "run-tests.sh").read_text()
+        self.assertIn(
+            "uv sync",
+            script,
+            "run-tests.sh never runs 'uv sync' -- it relies on the venv being provisioned "
+            "elsewhere, so a fresh clone has no ruff/pytest and an ambient ruff is used "
+            "silently instead (issue #89)",
+        )
+        for extra in ("--extra test", "--extra lint"):
+            self.assertIn(
+                extra,
+                script,
+                f"run-tests.sh's sync does not request '{extra}', so the tools it then "
+                "invokes with 'uv run' may resolve outside the venv (issue #89)",
+            )
+
 
 class TestReadme(unittest.TestCase):
     """Validate README quality for marketplace distribution."""

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -698,6 +698,29 @@ class TestHookInfrastructure(unittest.TestCase):
             "install-hooks.sh missing at repo root — needed to install hooks into .git/hooks/",
         )
 
+    def test_ci_runs_the_eval_import_smoke_test(self):
+        """test.yml must have a job that installs the eval extra and runs the smoke test.
+
+        tests/test_eval_imports.py is excluded from the default suite, so nothing runs it
+        unless CI does. An excluded test with no job behind it is worse than no test --
+        it looks like coverage while providing none (issue #122).
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "test.yml"
+        self.assertTrue(workflow.exists(), ".github/workflows/test.yml missing")
+        content = workflow.read_text()
+        self.assertIn(
+            "tests/test_eval_imports.py",
+            content,
+            "no CI job runs tests/test_eval_imports.py, which the default suite excludes -- "
+            "the eval harness's dependency surface would be untested everywhere",
+        )
+        self.assertIn(
+            "--extra eval",
+            content,
+            "CI runs the eval import smoke test without syncing '--extra eval', so it would "
+            "fail on a missing deepeval rather than testing anything",
+        )
+
     def test_release_workflow_checks_version_consistency(self):
         """release.yml must run check_release_version.py against the tag it is building.
 

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -698,6 +698,29 @@ class TestHookInfrastructure(unittest.TestCase):
             "install-hooks.sh missing at repo root — needed to install hooks into .git/hooks/",
         )
 
+    def test_release_workflow_checks_version_consistency(self):
+        """release.yml must run check_release_version.py against the tag it is building.
+
+        The checker being correct is worth nothing if nothing calls it -- an unwired
+        guard is the same silent pass it exists to prevent. This asserts the wiring,
+        and that the tag is actually passed rather than the script being run bare.
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "release.yml"
+        self.assertTrue(workflow.exists(), ".github/workflows/release.yml missing")
+        content = workflow.read_text()
+        self.assertIn(
+            "check_release_version.py",
+            content,
+            "release.yml does not run skill/check_release_version.py, so a tag that matches "
+            "neither README.md nor CHANGELOG.md would publish a mislabeled release",
+        )
+        self.assertIn(
+            "github.ref_name",
+            content,
+            "release.yml runs check_release_version.py without passing github.ref_name, "
+            "so it cannot compare anything against the tag being released",
+        )
+
     def test_github_actions_workflow_exists(self):
         workflow = REPO_ROOT / ".github" / "workflows" / "test.yml"
         self.assertTrue(

--- a/skill/tests/test_eval_imports.py
+++ b/skill/tests/test_eval_imports.py
@@ -1,0 +1,83 @@
+"""Smoke test for the eval harness's third-party surface (issue #122).
+
+The unit suite never touches `anthropic` or `deepeval`: `eval/executor.py` imports
+anthropic lazily inside a function body, and `tests/test_evals.py` is excluded from
+the default run. So a dependency upgrade could break the harness completely and every
+test would still pass -- which is exactly what happened when the lockfile was
+refreshed across `deepeval` 3.9.9 -> 4.1.8, a major version.
+
+This file mirrors the imports and constructions `tests/test_evals.py` performs, so a
+signature or module move in either package fails here instead of surfacing mid-cycle
+the next time someone tries to validate a prompt change.
+
+**No API calls.** `AnthropicModel` requires a key at construction time in deepeval 4.x,
+so a clearly-fake one is passed. Nothing here reaches the network, and this file must
+stay that way -- the moment it needs a real key it stops being runnable in CI and
+becomes another gate that quietly does not run.
+
+Excluded from the default suite (see `addopts` in pyproject.toml) because it needs the
+`eval` extra, which the project installs separately. The `eval-imports` job in
+.github/workflows/test.yml syncs that extra and runs this file. It is deliberately not
+guarded by a skip: a skipped smoke test is indistinguishable from a passing one.
+"""
+
+import unittest
+
+from deepeval.metrics import GEval
+from deepeval.models import AnthropicModel
+from deepeval.test_case import LLMTestCase, LLMTestCaseParams
+
+# Matches tests/test_evals.py's JUDGE_MODEL. Kept in sync deliberately: the point is to
+# exercise the same construction the real harness performs.
+JUDGE_MODEL_NAME = "claude-haiku-4-5-20251001"
+
+# Obviously fake, and never used against the network -- construction only.
+DUMMY_API_KEY = "sk-ant-dummy-key-for-construction-only"
+
+
+class TestEvalHarnessImports(unittest.TestCase):
+    """Every symbol tests/test_evals.py imports must still exist and construct."""
+
+    def test_anthropic_client_class_is_importable(self):
+        """eval/executor.py does `import anthropic` then `anthropic.Anthropic()`."""
+        import anthropic
+
+        self.assertTrue(
+            hasattr(anthropic, "Anthropic"),
+            "anthropic.Anthropic is gone -- eval/executor.py's client construction is broken",
+        )
+
+    def test_judge_model_constructs(self):
+        """tests/test_evals.py builds this at module import time, so a signature change
+        there breaks collection of the entire eval suite, not just one test."""
+        model = AnthropicModel(model=JUDGE_MODEL_NAME, api_key=DUMMY_API_KEY)
+        self.assertIsNotNone(model)
+
+    def test_geval_metric_constructs(self):
+        """GEval is the scoring surface the rubrics are written against."""
+        metric = GEval(
+            name="smoke",
+            criteria="A placeholder criterion used only to construct the metric.",
+            evaluation_params=[LLMTestCaseParams.ACTUAL_OUTPUT],
+            model=AnthropicModel(model=JUDGE_MODEL_NAME, api_key=DUMMY_API_KEY),
+        )
+        self.assertEqual(metric.name, "smoke")
+
+    def test_llm_test_case_carries_input_and_output(self):
+        case = LLMTestCase(input="a prompt", actual_output="a response")
+        self.assertEqual(case.input, "a prompt")
+        self.assertEqual(case.actual_output, "a response")
+
+    def test_rubrics_import_against_the_installed_deepeval(self):
+        """The rubric modules are the project's own code built on deepeval's API.
+
+        Importing them here catches the case where deepeval still provides everything
+        above but the rubrics use something it moved.
+        """
+        from eval.rubrics import rubric_1a  # noqa: F401
+
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skill/tests/test_release_version.py
+++ b/skill/tests/test_release_version.py
@@ -1,0 +1,123 @@
+"""Tests for the release version-consistency check (issue #89 follow-on, release guard).
+
+`tests/test_build.py::TestReadme::test_current_version_matches_changelog` ties
+README.md's "Current Version" to CHANGELOG.md's newest released heading. It cannot
+see the git tag, because at unit-test time there isn't one -- so both files can agree
+at v1.2.0 while the release is tagged v1.3.0, and the suite stays green while a
+mislabeled package is published.
+
+`check_release_version.py` closes that: the release workflow passes it the tag it is
+building, and it reports every disagreement between the tag, README, and CHANGELOG.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from check_release_version import check_release_version
+
+CHANGELOG_TEMPLATE = """# Changelog
+
+## Unreleased
+
+- something not yet released
+
+## v{released} (2026-07-17)
+
+- the previous release
+
+## v1.1.0 (2026-05-28)
+
+- older still
+
+## What Changed
+
+- a non-version heading that must not be mistaken for a release
+"""
+
+README_TEMPLATE = """# Skill
+
+Some prose.
+
+## Version Information
+
+**Current Version:** v{readme}
+
+More prose.
+"""
+
+
+def _repo(readme: str, released: str) -> TemporaryDirectory:
+    """Build a throwaway repo root with a README and CHANGELOG at the given versions."""
+    tmp = TemporaryDirectory()
+    root = Path(tmp.name)
+    (root / "skill").mkdir()
+    (root / "skill" / "README.md").write_text(README_TEMPLATE.format(readme=readme))
+    (root / "CHANGELOG.md").write_text(CHANGELOG_TEMPLATE.format(released=released))
+    return tmp
+
+
+class TestReleaseVersionCheck(unittest.TestCase):
+    def test_accepts_tag_matching_both_files(self):
+        with _repo(readme="1.2.0", released="1.2.0") as root:
+            self.assertEqual(check_release_version("v1.2.0", Path(root)), [])
+
+    def test_accepts_tag_without_v_prefix(self):
+        """The tag is the source of truth for its own spelling; 'v' is optional."""
+        with _repo(readme="1.2.0", released="1.2.0") as root:
+            self.assertEqual(check_release_version("1.2.0", Path(root)), [])
+
+    def test_rejects_tag_ahead_of_both_files(self):
+        """The hole the README<->CHANGELOG test cannot see: both agree, tag does not.
+
+        Publishing here would attach a package whose README says v1.2.0 to a release
+        labeled v1.3.0, with every existing test green.
+        """
+        with _repo(readme="1.2.0", released="1.2.0") as root:
+            problems = check_release_version("v1.3.0", Path(root))
+
+        self.assertTrue(problems, "a tag matching neither file must be reported")
+        joined = " ".join(problems)
+        self.assertIn("1.3.0", joined)
+        self.assertIn("1.2.0", joined)
+
+    def test_rejects_stale_readme(self):
+        with _repo(readme="1.2.0", released="1.3.0") as root:
+            problems = check_release_version("v1.3.0", Path(root))
+
+        self.assertTrue(problems, "a README behind the tag must be reported")
+        self.assertIn("README", " ".join(problems))
+
+    def test_rejects_changelog_without_the_release(self):
+        with _repo(readme="1.3.0", released="1.2.0") as root:
+            problems = check_release_version("v1.3.0", Path(root))
+
+        self.assertTrue(problems, "a CHANGELOG lacking the tagged release must be reported")
+        self.assertIn("CHANGELOG", " ".join(problems))
+
+    def test_reports_both_problems_at_once(self):
+        """A maintainer should learn about every mismatch in one run, not one per re-tag."""
+        with _repo(readme="1.1.0", released="1.2.0") as root:
+            problems = check_release_version("v1.3.0", Path(root))
+
+        self.assertEqual(len(problems), 2, f"expected a README and a CHANGELOG problem, got: {problems}")
+
+    def test_reports_missing_readme_version_line(self):
+        with TemporaryDirectory() as name:
+            root = Path(name)
+            (root / "skill").mkdir()
+            (root / "skill" / "README.md").write_text("# Skill\n\nNo version line here.\n")
+            (root / "CHANGELOG.md").write_text(CHANGELOG_TEMPLATE.format(released="1.3.0"))
+            problems = check_release_version("v1.3.0", root)
+
+        self.assertTrue(problems)
+        self.assertIn("Current Version", " ".join(problems))
+
+    def test_ignores_unreleased_and_non_version_headings(self):
+        """'## Unreleased' and '## What Changed' must not be read as the newest release."""
+        with _repo(readme="1.2.0", released="1.2.0") as root:
+            self.assertEqual(check_release_version("v1.2.0", Path(root)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #89. Advances #122 (does not close it — see below).

Four commits, each with its RED observed before the fix.

## `run-tests.sh` never provisioned its own venv (#89)

It called `uv run` and relied on something else having synced the extras. Both CI workflows do exactly that, which is why the script was never observed running unprovisioned.

A single counterfactual run after `rm -rf .venv` against the pre-fix script produced **both** failure modes at once:

```
All checks passed!                          ← ruff=0
.venv/bin/python3: No module named pytest   ← tests=1
✗ Checks failed (ruff=0 tests=1)
```

The pytest half is #89 as filed. The ruff half is worse and was not in the original report: `uv run ruff` found an ambient `/root/.local/bin/ruff` **0.15.8 — below the `>=0.16.0` floor `pyproject.toml` declares** — and the lint gate reported green while running it. The reporter saw `ruff=2` instead only because their machine had no ambient ruff to fall through to.

The script now syncs `--extra test --extra lint` itself. After the fix, `rm -rf .venv && bash run-tests.sh` → 163 passed, and `ruff` resolves to `.venv/bin/ruff` 0.16.3.

## A matching README and CHANGELOG can still disagree with the tag

`test_current_version_matches_changelog` (added last cycle) ties the two files to each other. It cannot see the tag — at unit-test time there isn't one. So both files can agree at v1.2.0 while the release is tagged v1.3.0, and every test stays green while a mislabeled package publishes.

`skill/check_release_version.py` takes the tag and reports every disagreement in one pass; `release.yml` runs it against `github.ref_name` immediately after checkout, before tests or build spend any time. Stdlib-only, so it needs no uv setup.

Demonstrated against the real repo before the bump in this PR:

```
$ python3 check_release_version.py v1.3.0
  - README says v1.2.0 but the release is tagged v1.3.0 -- ...
  - CHANGELOG's newest released heading is v1.2.0 -- promote '## Unreleased' to '## v1.3.0'
```

Eight test cases cover a matching tag, a bare tag with no `v`, a tag ahead of both files, a stale README, a CHANGELOG missing the release, both problems reported together, a README with no version line, and confirmation that `## Unreleased` and prose headings like `## What Changed` are not mistaken for the newest release.

## Nothing exercised the eval harness's dependency surface (#122)

`eval/executor.py` imports `anthropic` lazily inside a function body, and `tests/test_evals.py` is excluded from the default run. So the `deepeval` 3.9.9 → 4.1.8 major bump in the previous PR could have broken the harness completely with every test green.

`tests/test_eval_imports.py` mirrors what `test_evals.py` imports and constructs. **No API calls, no secret** — `AnthropicModel` requires a key at construction in deepeval 4.x, so a clearly-fake one is passed — which is why it can run on every push and PR.

Placement follows the project's existing dependency boundary rather than dissolving it: the file needs the `eval` extra, so it is excluded from the default suite via `addopts` and run by a dedicated `eval-imports` job that syncs it. **Not skip-guarded** — a skipped smoke test is indistinguishable from a passing one, which is the failure mode this whole series has been closing.

Two findings recorded on #122 rather than acted on here:

- **`LLMTestCaseParams` is deprecated in deepeval 4.x** in favour of `SingleTurnParams`, and `test_evals.py:22` imports it. The smoke test now emits that warning on every CI run, so removal won't arrive unannounced. Migrating needs a real eval run to verify.
- **`test_evals.py:38` constructs `AnthropicModel` at module level**, and deepeval 4.x demands the key at construction — so a missing key fails collection of the *entire* eval suite, not one test.

The smoke test proves the API surface is intact. It says nothing about **scoring behavior** against the baselines in `skill/eval/results/`, which is why #122 stays open pending a ~$2–5 run.

## v1.3.0

The Unreleased section described only the #114 build extraction. I completed it before promoting rather than tag an incomplete record — the lockfile correction (#113), the four hygiene gaps, and the documentation corrections were all missing.

Minor rather than major: the published `.skill` package is unchanged in structure and the skill's interface is untouched. **Windows builders do face a new requirement** — `build-skill.ps1` now needs a Python 3 interpreter, since it wraps `build.py` rather than implementing the build itself — called out as a blockquote at the top of the release rather than buried.

## Verification

```
163 passed, 153 subtests passed
mypy clean across 24 source files
check_release_version.py v1.3.0 → passes; v1.4.0 → fails on both files
```

Non-vacuity shown for both wiring tests by deleting what they assert and observing the failure: removing the `eval-imports` job from `test.yml` (56 → 33 lines), and removing the version-check step from `release.yml`.

One process note: for the two workflow-wiring tests I wired first and proved non-vacuity by removal, rather than strictly test-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_