### PR TITLE
Grant contents:write so the release workflow can actually publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    # Required by softprops/action-gh-release to create the Release and upload the
+    # .skill asset. Without it GITHUB_TOKEN takes the repository default, which is
+    # read-only, and the final step fails with "403 Resource not accessible by
+    # integration". Every release run in this repo's history failed that way; each
+    # release was then published by hand, so the red workflow blocked nothing and
+    # there was never a reason to open the log.
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v7
 

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -744,6 +744,31 @@ class TestHookInfrastructure(unittest.TestCase):
             "so it cannot compare anything against the tag being released",
         )
 
+    def test_release_workflow_grants_contents_write(self):
+        """release.yml's job must declare permissions: contents: write.
+
+        Without it GITHUB_TOKEN gets the repository default (read-only) and
+        softprops/action-gh-release fails with "403 Resource not accessible by
+        integration - create-a-release". Every release run in this repo's history
+        failed exactly this way and each release was published by hand instead, so
+        the red workflow never blocked anything and nobody had reason to look.
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "release.yml"
+        self.assertTrue(workflow.exists(), ".github/workflows/release.yml missing")
+        content = workflow.read_text()
+        self.assertIn(
+            "permissions:",
+            content,
+            "release.yml declares no 'permissions:' block, so GITHUB_TOKEN falls back to the "
+            "repository default (read-only) and creating the GitHub Release 403s",
+        )
+        self.assertRegex(
+            content,
+            r"permissions:\s*\n\s+contents:\s*write",
+            "release.yml does not grant 'contents: write', which is the permission "
+            "softprops/action-gh-release needs to create a release and upload the .skill asset",
+        )
+
     def test_github_actions_workflow_exists(self):
         workflow = REPO_ROOT / ".github" / "workflows" / "test.yml"
         self.assertTrue(


### PR DESCRIPTION
## The defect

`release.yml` declared no `permissions:` block, so `GITHUB_TOKEN` fell back to the repository default (read-only) and `softprops/action-gh-release` failed its final step:

```
👩‍🏭 Creating new GitHub release for tag v1.3.0...
⚠️ GitHub release failed with status: 403
Resource not accessible by integration
Skip retry — your GitHub token/PAT does not have the required permission to create a release
```

**This is not new to v1.3.0.** Every release run in this repository's history — v1.0.1, v1.0.2, v1.1.0, v1.2.0, and now v1.3.0 — finished with conclusion `failure` for the same reason. Each release was then published by hand, so the artifact appeared, the red workflow blocked nothing, and there was never an occasion to open the log.

That is the silent-failure shape this project keeps finding, inverted: not a green check that could never fail, but a red one nobody had reason to read.

## The fix

```yaml
permissions:
  contents: write
```

`pr-metrics.yml` already sets a job-level permissions block, so this follows an in-repo precedent rather than introducing a pattern. `contents: write` is the minimum `action-gh-release` needs to create the release and upload the asset — no other scopes granted.

## Called shot

*Test:* `test_release_workflow_grants_contents_write`. *Expected failure:* `AssertionError: 'permissions:' not found in ...`. Observed exactly that before the change.

The test asserts both that a `permissions:` block exists and that it resolves to `contents: write`, so a future edit that keeps the block but drops the scope still fails.

## Verification

```
164 passed, 153 subtests passed
YAML parses; jobs.release.permissions == {'contents': 'write'}
```

## Landing this does not by itself publish v1.3.0

The `v1.3.0` tag points at `a48bfb7`, which predates this fix, and Actions reads `release.yml` **from the tag's own tree**. Re-running the failed run will fail again for the same reason.

After merge, the tag has to be re-pointed at a commit containing this change:

```bash
git fetch origin main
git tag -f v1.3.0 origin/main
git push -f origin v1.3.0
```

That re-fires the workflow against a tree that has the permission, and the release publishes with `pdca-framework.skill` attached. I cannot do this myself — this session's credentials are refused (403) on tag refs, which is a separate restriction from the one this PR fixes.

Worth watching the first run either way: the version-consistency guard added in #126 has now run once and passed, but this permission has never succeeded in this repository, so its first green is worth reading rather than trusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_