### PR TITLE
Add a manually-dispatched workflow to run prompt evals in CI

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,83 @@
+name: Run PDCA Prompt Evals
+
+# Manual dispatch only. A full eval run costs roughly $2-5 in API spend, so this
+# must never fire on push or pull_request. The test suite asserts that.
+#
+# The point of running evals here rather than locally is that ANTHROPIC_API_KEY
+# stays in GitHub secrets: no contributor has to paste a live credential into a
+# terminal, a .env file, or an agent session to measure a prompt change.
+on:
+  workflow_dispatch:
+    inputs:
+      test_id:
+        description: >-
+          pytest target. Prefer a single parametrized scenario over a whole class -
+          a class runs every scenario in its file and costs proportionally more.
+          e.g. tests/test_evals.py::TestPrompt2Evals::test_2_scenario[2-first-step]
+        required: true
+        type: string
+      shots:
+        description: >-
+          How many times to run it. A single run cannot attribute a failure to a
+          prompt change - scenarios fail on text nobody touched. Use several when
+          the result will inform a decision.
+        required: false
+        default: "1"
+        type: string
+
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+
+    # Read-only: this job checks out the repository and calls the Anthropic API.
+    # It never writes to the repository.
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install eval dependencies
+        run: uv sync --locked --extra test --extra eval
+        working-directory: skill
+
+      - name: Run evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        working-directory: skill
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set for this repository." \
+                 "Add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+          shots="${{ inputs.shots }}"
+          case "$shots" in
+            ''|*[!0-9]*) echo "::error::shots must be a positive integer, got '$shots'"; exit 1 ;;
+          esac
+          # Each shot is a separate invocation so one failing shot does not abort the
+          # rest: attribution needs the whole distribution, not the first failure.
+          failures=0
+          for i in $(seq 1 "$shots"); do
+            echo "::group::Shot $i of $shots"
+            bash run-evals.sh "${{ inputs.test_id }}" || failures=$((failures + 1))
+            echo "::endgroup::"
+          done
+          echo "Completed $shots shot(s); $failures did not pass."
+          echo "A non-zero count is data, not necessarily a defect - read the recorded"
+          echo "responses in the artifact before attributing anything."
+
+      # Uploaded unconditionally: a failed run is exactly the one whose recorded
+      # responses need reading. eval/results/ is gitignored and regenerated per run.
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: skill/eval/results/
+          if-no-files-found: warn

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -744,6 +744,42 @@ class TestHookInfrastructure(unittest.TestCase):
             "so it cannot compare anything against the tag being released",
         )
 
+    def test_eval_workflow_exists_and_passes_api_key(self):
+        """A dispatchable workflow must run the eval harness with the API key wired through.
+
+        The eval suite is the only mechanism that can tell us whether a prompt change
+        helped, and it needs a credential no contributor should paste into a session.
+        Running it from CI keeps ANTHROPIC_API_KEY in GitHub secrets. A workflow that
+        exists but never passes the secret through would look configured and fail only
+        after paying for checkout and dependency install, so both are asserted.
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "evals.yml"
+        self.assertTrue(
+            workflow.exists(),
+            ".github/workflows/evals.yml missing - the eval harness has no way to run "
+            "without a contributor supplying a key by hand",
+        )
+        content = workflow.read_text()
+        self.assertIn(
+            "workflow_dispatch",
+            content,
+            "evals.yml must be manually dispatchable - eval runs cost money and must "
+            "never fire automatically on push or pull_request",
+        )
+        for forbidden in ("on: push", "pull_request:"):
+            self.assertNotIn(
+                forbidden,
+                content,
+                f"evals.yml declares '{forbidden}', which would spend API budget on every "
+                "push or PR; eval runs are manual by design",
+            )
+        self.assertIn(
+            "secrets.ANTHROPIC_API_KEY",
+            content,
+            "evals.yml does not pass secrets.ANTHROPIC_API_KEY, so the run would fail at "
+            "the first API call having already spent setup time",
+        )
+
     def test_github_actions_workflow_exists(self):
         workflow = REPO_ROOT / ".github" / "workflows" / "test.yml"
         self.assertTrue(


### PR DESCRIPTION
Adds `.github/workflows/evals.yml` so the eval harness can run without a live `ANTHROPIC_API_KEY` reaching a terminal, a `.env` file, or an agent session. The key stays in GitHub secrets, where nothing that reads this repository can see it.

Needed immediately for #131's Step 0 measurement, but useful for every future prompt change.

## Design decisions worth reviewing

**`workflow_dispatch` only.** A full run costs roughly $2–5, so an automatic trigger would spend budget continuously. The test asserts both that the workflow is dispatchable *and* that it declares no `push`/`pull_request` trigger — so a later edit that adds one fails the suite rather than quietly draining the account.

**`test_id` is required with no default.** A run is always a deliberate choice of scope. The input description steers toward a single parametrized scenario rather than a whole class, because a class runs every scenario in its file — for the current measurement that's the difference between 3 scenarios and 11.

**`shots` exists because one run cannot attribute a failure.** `3-all-complete` was measured failing 3 of 18 runs against an *unmodified* master. A single red shot proves nothing. Each shot is a separate invocation so an early failure doesn't abort the rest — attribution needs the whole distribution, not the first failure.

**Results upload with `if: always()`**, because a failed run is precisely the one whose recorded responses need reading. `permissions: contents: read` only.

## Called shot

*Test:* `test_eval_workflow_exists_and_passes_api_key`. *Expected failure:* `AssertionError: .github/workflows/evals.yml missing`. Observed exactly that.

The test also asserts `secrets.ANTHROPIC_API_KEY` is passed through — a workflow that exists but never wires the secret looks configured and fails only after paying for checkout and dependency install. The run step additionally guards at runtime with a clear `::error::` if the secret is empty, rather than surfacing an opaque SDK auth error.

## Verification

```
164 passed, 153 subtests passed
YAML parses; triggers == ['workflow_dispatch']; permissions == {'contents': 'read'}
```

## Sequencing note

`workflow_dispatch` requires the workflow to exist **on the default branch** before it can be dispatched at all. This has to land on `main` before any eval run can be triggered — including a run against the `claude/superpowers-interop` branch where #131's scenarios live.

Once merged, #131's Step 0 is three dispatches against that branch:

```
tests/test_evals.py::TestPrompt2Evals::test_2_scenario[2-superpowers-branch-finish]
tests/test_evals.py::TestPrompt2Evals::test_2_scenario[2-superpowers-tdd-precedence]
tests/test_evals.py::TestPrompt3Evals::test_3_scenario[3-superpowers-verification-not-check]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_