### PR TITLE
Enforce the per-PR CHANGELOG rule, and backfill what was missed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,32 @@ jobs:
       - name: Build and test
         run: bash skill/run-tests.sh
 
+  # CONTRIBUTING.md requires every PR to add a CHANGELOG entry under '## Unreleased'.
+  # Nothing enforced it and it was routinely missed -- CLAUDE.md mentions CHANGELOG only
+  # under Releasing, and the 1b prompt's Full Cycle Scope checklist omits it. The check
+  # needs a diff, which exists only on a pull request, so it runs here rather than in the
+  # unit suite (which could at most assert that some Unreleased section exists -- true
+  # forever after one entry, and blind to the PR that forgot).
+  #
+  # Dependabot is exempt: its bumps are summarised once at release time, as v1.2.0's
+  # "Dependency Updates" section did, rather than one entry per automated PR.
+  changelog:
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: the merge base is required for a correct three-dot diff.
+          # A shallow clone yields a wrong diff rather than an obvious failure.
+          fetch-depth: 0
+
+      - name: Require a CHANGELOG entry
+        run: python3 skill/check_changelog.py "origin/${{ github.base_ref }}"
+
   # The unit suite never imports anthropic or deepeval -- executor.py imports anthropic
   # lazily inside a function, and test_evals.py is excluded from the default run -- so a
   # dependency upgrade can break the eval harness with every test still green (issue #122).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # PDCA Framework Skill - Update Summary
 
+## Unreleased
+
+### Build and Distribution
+
+- **The release workflow could never publish.** `release.yml` declared no `permissions:`
+  block, so `GITHUB_TOKEN` fell back to the repository default (read-only) and
+  `softprops/action-gh-release` failed with `403 Resource not accessible by integration`.
+  Every release run in this repository's history — v1.0.1 through v1.3.0 — finished with
+  conclusion `failure` for this reason, and each release was published by hand instead, so
+  the red workflow blocked nothing and there was no occasion to read the log. Now grants
+  `contents: write`, with `test_release_workflow_grants_contents_write` asserting both the
+  block and the scope.
+
+### New Tooling
+
+- **`.github/workflows/evals.yml`** — manually-dispatched workflow for running prompt
+  evals in CI, so `ANTHROPIC_API_KEY` stays in GitHub secrets rather than reaching a
+  terminal, a `.env` file, or an agent session. `workflow_dispatch` only; the test suite
+  asserts no automatic trigger exists, since a full run costs roughly $2–5. Takes a
+  `test_id` (required, no default, so scope is always deliberate) and a `shots` count —
+  the latter because a single run cannot attribute a failure to a prompt change:
+  `3-all-complete` was measured failing 3 of 18 runs against an unmodified master.
+
+- **`skill/check_changelog.py`** — enforces `CONTRIBUTING.md`'s per-PR CHANGELOG rule,
+  which had no mechanism behind it and was routinely missed. Runs on pull requests only,
+  because the check needs a diff; a unit test could at most assert that some `##
+  Unreleased` section exists, which stays true forever after one entry and is blind to the
+  PR that forgot. Dependabot is exempt — its bumps are summarised once at release time.
+
+### Bug Fixes
+
+- **`run-evals.sh` never built the skill or synced the eval extra.** The harness reads the
+  built prompt files under `pdca-framework/references/`, which are gitignored artifacts. On
+  any tree without a prior build every scenario died with `FileNotFoundError` on
+  `do-prompts.md` before reaching the API — and each dead shot was reported as "did not
+  pass", indistinguishable in a summary count from the model actually failing the scenario.
+  A harness that cannot run must not read like a harness delivering a verdict. Same shape
+  as #89, in the script next door.
+
+### Dependency Updates
+
+- setuptools `>=83.0.0` → `>=84.0.0`.
+
 ## v1.3.0 (2026-08-18)
 
 > **Windows builders:** `build-skill.ps1` now requires a Python 3 interpreter on `PATH` as

--- a/skill/check_changelog.py
+++ b/skill/check_changelog.py
@@ -1,0 +1,112 @@
+"""Require a CHANGELOG entry on pull requests that change behavior.
+
+CONTRIBUTING.md requires every PR to add an entry under `## Unreleased`. Nothing
+enforced it, and it was routinely missed: CLAUDE.md mentions CHANGELOG only under
+Releasing (reading as a release-time task), and the 1b prompt's Full Cycle Scope
+checklist -- whose stated purpose is "these are not cleanup items, name them in the
+plan so CHECK can verify them like any other step" -- omits it entirely. Five
+substantive changes across three PRs shipped without an entry before it was noticed.
+
+This is deliberately a PR-scoped check rather than a unit test. A unit test cannot see
+a diff, so the most it could assert is that `## Unreleased` exists and is non-empty --
+which passes forever once any single entry is added, and would never catch the PR that
+forgot. The information needed lives only in the pull request, so the guard runs there.
+
+    python3 check_changelog.py <base-ref>
+
+Exits 0 when satisfied, 1 otherwise, printing each problem to stderr.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+CHANGELOG = "CHANGELOG.md"
+
+# Paths whose change is release-note material. Prose-only files (README, CONTRIBUTING,
+# AGENTS) are deliberately absent: a guard that fires on a typo fix trains people to
+# work around it, and a guard people route around protects nothing.
+REQUIRES_ENTRY = (
+    "skill/",
+    "1. Plan/",
+    "2. Do/",
+    "3. Check/",
+    "4. Act/",
+    "Human Working Agreements.md",
+    ".github/workflows/",
+)
+
+# Generated run artifacts, gitignored. Their presence in a diff is not a change.
+EXEMPT = ("skill/eval/results/",)
+
+
+def needs_changelog_entry(changed_paths: list[str]) -> bool:
+    """True when any changed path is release-note material."""
+    return any(_triggering(changed_paths))
+
+
+def _triggering(changed_paths: list[str]) -> list[str]:
+    return [
+        path
+        for path in changed_paths
+        if path != CHANGELOG
+        and not path.startswith(EXEMPT)
+        and path.startswith(REQUIRES_ENTRY)
+    ]
+
+
+def check_changelog(changed_paths: list[str]) -> list[str]:
+    """Return problems; empty means the diff satisfies CONTRIBUTING.md's rule."""
+    triggering = _triggering(changed_paths)
+    if not triggering:
+        return []
+    if CHANGELOG in changed_paths:
+        return []
+
+    shown = ", ".join(sorted(triggering)[:3])
+    more = f" (and {len(triggering) - 3} more)" if len(triggering) > 3 else ""
+    return [
+        f"This pull request changes {shown}{more} but does not touch {CHANGELOG}. "
+        "CONTRIBUTING.md requires an entry under an '## Unreleased' section, grouped "
+        "under a '### Category' subheading. If the change requires action from existing "
+        "users, add a '### Migration Notes' subsection. Running `/update-changelog` in "
+        "Claude Code drafts entries from your commits."
+    ]
+
+
+def _changed_paths(base_ref: str) -> list[str]:
+    """Paths differing between the merge base and HEAD."""
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in diff.stdout.splitlines() if line]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0] if argv else 'check_changelog.py'} <base-ref>", file=sys.stderr)
+        return 2
+
+    try:
+        paths = _changed_paths(argv[1])
+    except subprocess.CalledProcessError as error:
+        print(f"Could not diff against {argv[1]}: {error.stderr.strip()}", file=sys.stderr)
+        return 2
+
+    problems = check_changelog(paths)
+    if problems:
+        print("CHANGELOG check failed:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"CHANGELOG check passed ({len(paths)} path(s) changed).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -744,6 +744,30 @@ class TestHookInfrastructure(unittest.TestCase):
             "so it cannot compare anything against the tag being released",
         )
 
+    def test_ci_enforces_the_changelog_rule_on_pull_requests(self):
+        """test.yml must run check_changelog.py against the PR base.
+
+        CONTRIBUTING.md's per-PR CHANGELOG rule had no mechanism behind it and was
+        routinely missed. The check needs a diff, which exists only on a pull request,
+        so it cannot live in the unit suite -- but the wiring can be asserted here.
+        fetch-depth: 0 is load-bearing: without full history the merge base is absent
+        and the diff would be wrong rather than absent, which is worse.
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "test.yml"
+        content = workflow.read_text()
+        self.assertIn(
+            "check_changelog.py",
+            content,
+            "test.yml does not run check_changelog.py, so CONTRIBUTING.md's CHANGELOG "
+            "requirement stays a documented gate with nothing behind it",
+        )
+        self.assertIn(
+            "fetch-depth: 0",
+            content,
+            "the changelog job needs full history for the merge base; a shallow clone "
+            "produces a wrong diff rather than an obvious failure",
+        )
+
     def test_eval_workflow_exists_and_passes_api_key(self):
         """A dispatchable workflow must run the eval harness with the API key wired through.
 

--- a/skill/tests/test_changelog_guard.py
+++ b/skill/tests/test_changelog_guard.py
@@ -1,0 +1,71 @@
+"""Tests for the CHANGELOG entry guard (CONTRIBUTING.md's per-PR requirement).
+
+CONTRIBUTING.md line 110 requires every PR to add an entry under `## Unreleased`.
+Nothing enforced it: CLAUDE.md mentions CHANGELOG only under Releasing, and the 1b
+prompt's Full Cycle Scope checklist -- the list whose stated purpose is "these are not
+cleanup items, name them in the plan so CHECK can verify them" -- omits it entirely.
+Five substantive changes across three PRs shipped without an entry before anyone noticed.
+
+The rule is expressed as a pure function over changed paths so it is testable without a
+git repository or a live pull request.
+"""
+
+import unittest
+
+from check_changelog import CHANGELOG, check_changelog, needs_changelog_entry
+
+
+class TestNeedsChangelogEntry(unittest.TestCase):
+    def test_skill_source_requires_an_entry(self):
+        self.assertTrue(needs_changelog_entry(["skill/build.py"]))
+
+    def test_phase_masters_require_an_entry(self):
+        for master in (
+            "1. Plan/1a Analyze to determine approach for achieving the goal.md",
+            "2. Do/2. Test Drive the Change.md",
+            "3. Check/3. Completeness Check.md",
+            "4. Act/4. Retrospect for continuous improvement.md",
+            "Human Working Agreements.md",
+        ):
+            with self.subTest(master=master):
+                self.assertTrue(needs_changelog_entry([master]))
+
+    def test_workflows_require_an_entry(self):
+        """CI and release behavior is user-visible to contributors."""
+        self.assertTrue(needs_changelog_entry([".github/workflows/release.yml"]))
+
+    def test_readme_alone_does_not_require_an_entry(self):
+        """Prose fixes are not release-note material; the rule must not cry wolf."""
+        self.assertFalse(needs_changelog_entry(["README.md", "CONTRIBUTING.md"]))
+
+    def test_changelog_alone_does_not_require_an_entry(self):
+        self.assertFalse(needs_changelog_entry([CHANGELOG]))
+
+    def test_generated_eval_results_do_not_require_an_entry(self):
+        """eval/results/ is a gitignored run artifact, not a change."""
+        self.assertFalse(needs_changelog_entry(["skill/eval/results/report_1.md"]))
+
+    def test_empty_diff_does_not_require_an_entry(self):
+        self.assertFalse(needs_changelog_entry([]))
+
+
+class TestCheckChangelog(unittest.TestCase):
+    def test_missing_entry_is_reported(self):
+        problems = check_changelog(["skill/build.py"])
+        self.assertTrue(problems)
+        self.assertIn("CHANGELOG.md", " ".join(problems))
+
+    def test_entry_present_passes(self):
+        self.assertEqual(check_changelog(["skill/build.py", CHANGELOG]), [])
+
+    def test_unaffected_paths_pass(self):
+        self.assertEqual(check_changelog(["README.md"]), [])
+
+    def test_problem_names_a_triggering_path(self):
+        """The message must say WHICH change triggered the requirement."""
+        problems = check_changelog(["skill/build.py", "docs/x.md"])
+        self.assertIn("skill/build.py", " ".join(problems))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

`CONTRIBUTING.md:110` requires every PR to add an entry under `## Unreleased`. Nothing enforced it, and **five substantive changes across three PRs shipped without one** — two already merged to `main`, which had no `## Unreleased` section at all.

The rule is invisible where an agent actually reads:

| File | Status |
|---|---|
| `CLAUDE.md` — auto-loaded by Claude Code | CHANGELOG appears only under *Releasing* step 2, reading as a release-time task |
| **1b "Full Cycle Scope"** | Enumerates build system and documentation. **Omits CHANGELOG** — despite existing precisely so that "these are not cleanup items, name them in the plan so CHECK can verify them like any other step" |
| CHECK | Generic "Documentation updated" checkbox |
| `AGENTS.md`, `SUPERVISION-PROTOCOL.md` | Nothing |

Same shape as the release checklist's README-version step that was skipped at v1.2.0: a documented requirement with no mechanism behind it.

## Why a CI check and not a test

A unit test cannot see a diff. The most it could assert is that *some* `## Unreleased` section exists and is non-empty — true forever after a single entry, and blind to the PR that forgot. The information needed exists only on the pull request, so the guard runs there.

The rule itself is a pure function over changed paths, so it *is* unit-testable without git or a live PR — 11 cases covering skill sources, each phase master, workflows, prose-only diffs, the changelog alone, generated eval results, and an empty diff.

## Scope choices worth reviewing

- **Triggers on** `skill/`, the four phase masters, `Human Working Agreements.md`, `.github/workflows/`.
- **Prose-only files are deliberately excluded** (README, CONTRIBUTING, AGENTS). A guard that fires on a typo fix trains people to route around it, and a guard people route around protects nothing.
- **`skill/eval/results/` is exempt** — gitignored run artifacts, not a change.
- **Dependabot is exempt.** Its bumps get summarised once at release time, as v1.2.0's "Dependency Updates" section did, rather than one entry per automated PR. Without this, all four open dependabot PRs would be blocked.
- **`fetch-depth: 0` is load-bearing.** Without full history the merge base is absent and the three-dot diff is *wrong* rather than empty — a silent wrong answer instead of a loud failure.

## Called shots

*Test:* `tests/test_changelog_guard.py`. *Expected failure:* `ModuleNotFoundError: No module named 'check_changelog'`. Observed.
*Test:* `test_ci_enforces_the_changelog_rule_on_pull_requests`. *Expected failure:* missing `check_changelog.py` reference in `test.yml`. Observed.

**And demonstrated against a real diff — its own.** Run against this branch's first commit, before the CHANGELOG entry existed:

```
CHANGELOG check failed:
  - This pull request changes .github/workflows/test.yml, skill/check_changelog.py,
    skill/tests/test_build.py (and 1 more) but does not touch CHANGELOG.md.
    CONTRIBUTING.md requires an entry under an '## Unreleased' section...
```

With the entry: `CHANGELOG check passed (5 path(s) changed).` This PR is the guard's first subject.

## Backfill

`## Unreleased` now covers the release-workflow permissions fix, the evals workflow, `check_changelog.py` itself, `run-evals.sh` never building the skill, and the setuptools bump.

**Not included:** the three commits on `claude/superpowers-interop`, which belong in that branch's own PR per the per-PR rule.

## Verification

```
177 passed, 158 subtests passed
mypy clean across 26 source files
```

## Deliberately not done

Adding CHANGELOG to the 1b prompt's Full Cycle Scope list. That is a **master-prompt edit**, and this repo requires eval measurement before shipping inline prompt text — the superpowers cycle (#131) just demonstrated why, with all three of its hypothesised guard clauses refuted by measurement. The failure message carries the guidance instead, which is arguably better placed: it appears exactly when it is needed. Worth a separate cycle if you want the prompt to say it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_