### PR TITLE
Record the pre-flight working agreement from cycle 5's retrospective

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,15 @@ See `skill/SUPERVISION-PROTOCOL.md` for the full protocol. Key rules:
 - All code changes require a failing test first (TDD, no exceptions)
 - Do not batch multiple steps without human confirmation between them
 
+**Establish the ground before the first action, not after the failed one:**
+
+- **Verify state before acting.** Use absolute paths; the working directory is not where you
+  assume. Search existing issues before filing one, and check what already exists before
+  building it.
+- **Design observability before the first run.** Before anything slow or costly, confirm you
+  will be able to read its result. A run whose output you cannot inspect has to be repeated,
+  and a broken mechanism reports a number that looks exactly like a measurement.
+
 ## Validating Prompt Changes
 
 Any edit to master prompt files or eval rubrics requires:


### PR DESCRIPTION
ACT outcome for #131. Two lines in `CLAUDE.md`, no code change.

## What it captures

Two failure modes recurred through the session, each discovered by failing rather than prevented:

**Working-directory drift.** Relative paths resolved against `skill/` instead of the repo root and vice versa — producing a demonstration that silently did not run, a truncated workflow file left on disk, and several repeated commands. Related: two duplicate issues were filed because existing ones weren't searched for (#113 and #89 already covered them).

**Observability designed after the fact.** The first eval run returned `5 shot(s); 5 did not pass` from a harness that never called the API. The second returned `2 did not pass` with reports unreachable behind an authenticated artifact download. **Three runs before one produced readable output**, and both bad runs returned a number that read exactly like a finding.

Both are the same shape: preconditions established by tripping over them. The agreement states them as pre-flight checks.

## Placement, and why not the two obvious alternatives

**Not `skill/SUPERVISION-PROTOCOL.md`** — it's referenced by `CLAUDE.md` but not auto-loaded. Putting it there repeats precisely the failure #134 just fixed: the CHANGELOG rule was correctly documented in `CONTRIBUTING.md` and invisible in practice because nothing loads that file during a cycle.

**Not `Human Working Agreements.md`** — that's a shipped master (`MASTER_FILES` → `working-agreements.md`), so it falls under *Validating Prompt Changes*. This cycle refuted three of three hypothesised guard clauses by measurement; adding prompt text on the assumption it helps is the exact move that discipline exists to prevent. If it belongs in the shipped skill, it deserves its own cycle with evidence.

**No CHANGELOG entry** — `check_changelog.py` deliberately excludes prose-only files, so this diff doesn't trigger the rule (`CHANGELOG check passed (0 path(s) changed)`). Adding one anyway would contradict the scope choice made in #134.

## A caveat I'd rather state than bury

**This is a documented gate with no mechanism behind it** — the same shape that failed for the release checklist's README step and for the CHANGELOG rule. Neither of these is CI-enforceable: "use absolute paths" and "check you can read the result first" are habits, not assertions. So this is genuinely weaker than the guards added in #132/#134, and should be understood as a reminder rather than a control.

## Verification

```
179 passed, 176 subtests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_