### PR TITLE
Tell "the harness never ran" apart from "the scenario failed"

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -62,15 +62,36 @@ jobs:
           esac
           # Each shot is a separate invocation so one failing shot does not abort the
           # rest: attribution needs the whole distribution, not the first failure.
+          #
+          # run-evals.sh exits 2 when it produced no verdict at all and 1 when a scenario
+          # genuinely failed. Counting both as "did not pass" is exactly how a harness
+          # that never called the API once reported "5 shot(s); 5 did not pass" and read
+          # as a confirmed hypothesis. They are counted separately here.
           failures=0
+          harness_errors=0
           for i in $(seq 1 "$shots"); do
             echo "::group::Shot $i of $shots"
-            bash run-evals.sh "${{ inputs.test_id }}" || failures=$((failures + 1))
+            set +e
+            bash run-evals.sh "${{ inputs.test_id }}"
+            shot_exit=$?
+            set -e
+            if [ "$shot_exit" -eq 2 ]; then
+              harness_errors=$((harness_errors + 1))
+            elif [ "$shot_exit" -ne 0 ]; then
+              failures=$((failures + 1))
+            fi
             echo "::endgroup::"
           done
-          echo "Completed $shots shot(s); $failures did not pass."
-          echo "A non-zero count is data, not necessarily a defect - read the recorded"
-          echo "responses in the artifact before attributing anything."
+
+          echo "Completed $shots shot(s): $failures scenario failure(s), $harness_errors harness error(s)."
+          if [ "$harness_errors" -gt 0 ]; then
+            echo "::error::$harness_errors shot(s) produced no verdict at all. Those shots" \
+                 "measured NOTHING - do not read them as scenario failures. Fix the harness" \
+                 "and re-run before drawing any conclusion."
+            exit 1
+          fi
+          echo "A non-zero failure count is data, not necessarily a defect - read the"
+          echo "recorded responses below before attributing anything."
 
       # Echoed into the log as well as uploaded. The reports carry the recorded model
       # responses, and eval/README.md requires diagnosing a failure from the response

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: skill
 
       - name: Type check (mypy)
-        run: uv run mypy eval tests build.py check_release_version.py
+        run: uv run mypy eval tests build.py check_changelog.py check_eval_ran.py check_release_version.py
         working-directory: skill
 
       - name: Build and test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **A dead eval harness could not be told apart from a failing scenario.** A shot that
+  dies before reaching the API — missing build artifact, absent key, network failure —
+  produces no scored result, but pytest exits non-zero either way, so a caller counting
+  exit codes reported a crash and a genuine failure identically. This was not
+  hypothetical: the first eval run of #131's Step 0 reported `5 shot(s); 5 did not pass`
+  from a harness that never called the API once, and it read exactly like a confirmed
+  hypothesis. `eval/README.md`'s thesis is that a broken eval is self-sealing, since the
+  eval *is* the mechanism meant to notice.
+- **`skill/check_eval_ran.py`** distinguishes them. The evidence was already in the
+  reports — a crashed shot leaves a Summary table with a header, a separator and no data
+  rows — so the check is a pure function over report text, needing no API key, no network
+  and no live run. That is deliberate: it has to work in exactly the conditions where the
+  harness cannot. `run-evals.sh` now exits **2** when nothing was measured, distinct from
+  **1** for a real scenario failure, and scopes the check to reports from the current run
+  so an earlier scored report cannot mask a run that scored nothing.
+- **`evals.yml` counts the two separately** and fails loudly on a harness error rather
+  than folding it into a "did not pass" tally.
+
 ### Optional superpowers interop (#131)
 
 - The pdca-framework skill now offers optional interoperation with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,15 @@ See `skill/SUPERVISION-PROTOCOL.md` for the full protocol. Key rules:
 - All code changes require a failing test first (TDD, no exceptions)
 - Do not batch multiple steps without human confirmation between them
 
+**Establish the ground before the first action, not after the failed one:**
+
+- **Verify state before acting.** Use absolute paths; the working directory is not where you
+  assume. Search existing issues before filing one, and check what already exists before
+  building it.
+- **Design observability before the first run.** Before anything slow or costly, confirm you
+  will be able to read its result. A run whose output you cannot inspect has to be repeated,
+  and a broken mechanism reports a number that looks exactly like a measurement.
+
 ## Validating Prompt Changes
 
 Any edit to master prompt files or eval rubrics requires:

--- a/skill/check_eval_ran.py
+++ b/skill/check_eval_ran.py
@@ -1,0 +1,119 @@
+"""Tell "the harness never ran" apart from "the scenario failed".
+
+A shot that dies before reaching the API -- a missing build artifact, an absent key,
+a network failure -- produces no scored result. But the runner's exit code is
+non-zero either way, so a caller counting exit codes reports both as "did not pass",
+which is indistinguishable from the model actually failing the scenario.
+
+The first eval run of #131's Step 0 reported "5 shot(s); 5 did not pass" from a
+harness that never called the API once. It read exactly like a confirmed hypothesis
+and would have justified a prompt change on no evidence. eval/README.md states why
+this class of defect is dangerous: a broken eval is self-sealing, because the eval
+*is* the mechanism that was supposed to notice.
+
+The evidence is already in the reports. EvalReporter renders a Summary table per
+run; a shot that crashed before scoring anything leaves that table with a header, a
+separator, and no data rows. So this is a pure function over report text -- it needs
+no API key, no network and no live run, which is the point: it has to work in
+exactly the conditions where the harness cannot.
+
+    python3 check_eval_ran.py <results-dir> [<results-dir> ...]
+
+Exits 0 when at least one scenario was scored, 1 when shots produced no verdict.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SUMMARY_HEADING = "## Summary"
+# The rendered separator row; everything between it and the blank line is data.
+SEPARATOR_PREFIX = "|---"
+
+
+def scored_scenarios(report_text: str) -> list[str]:
+    """Scenario ids that received a verdict in this report.
+
+    An empty list means the run produced no measurement -- not that it measured a
+    failure.
+    """
+    if SUMMARY_HEADING not in report_text:
+        return []
+
+    lines = report_text[report_text.index(SUMMARY_HEADING):].splitlines()
+    scenarios, past_separator = [], False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith(SEPARATOR_PREFIX):
+            past_separator = True
+            continue
+        if not past_separator:
+            continue
+        if not stripped.startswith("|"):
+            break  # table ended
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if cells and cells[0]:
+            scenarios.append(cells[0])
+    return scenarios
+
+
+def check_run(report_texts: list[str]) -> list[str]:
+    """Return problems. Empty means the run produced at least one real verdict."""
+    if not report_texts:
+        return [
+            "The eval run produced no report at all, so nothing was measured. "
+            "This is a harness failure, not a scenario outcome -- do not read the "
+            "runner's exit code as a verdict."
+        ]
+
+    if any(scored_scenarios(text) for text in report_texts):
+        return []
+
+    return [
+        f"{len(report_texts)} report(s) were written but none contains a scored "
+        "scenario, so the harness did not run to completion. Nothing was measured. "
+        "Common causes: the skill was not built (references/ missing), the API key "
+        "is absent, or the request never left the machine. Read the run log for the "
+        "underlying error rather than treating this as a scenario outcome."
+    ]
+
+
+def _read_reports(paths: list[str]) -> list[str]:
+    """Read reports from directories or individual files.
+
+    Callers should pass only the reports THIS run produced. eval/results/ accumulates
+    across runs, so a directory holding an earlier scored report would mask a current
+    run that scored nothing -- the same stale-artifact hazard BUILD.md documents for
+    the build.
+    """
+    texts: list[str] = []
+    for raw in paths:
+        path = Path(raw)
+        if path.is_dir():
+            texts.extend(report.read_text() for report in sorted(path.glob("*.md")))
+        elif path.is_file():
+            texts.append(path.read_text())
+    return texts
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(f"usage: {argv[0] if argv else 'check_eval_ran.py'} <results-dir> ...", file=sys.stderr)
+        return 2
+
+    texts = _read_reports(argv[1:])
+    problems = check_run(texts)
+    if problems:
+        print("Eval harness check failed:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    scored = sorted({s for text in texts for s in scored_scenarios(text)})
+    print(f"Eval harness ran: {len(texts)} report(s), scored {', '.join(scored)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skill/run-evals.sh
+++ b/skill/run-evals.sh
@@ -31,8 +31,41 @@ echo "=== Running PDCA Prompt Evaluations ==="
 echo "Judge model: claude-haiku-4-5-20251001"
 echo ""
 
+# Marker for "reports written by THIS run". eval/results/ accumulates across runs,
+# so checking the whole directory would let an earlier scored report mask a run that
+# scored nothing -- the stale-artifact hazard BUILD.md documents for the build.
+MARKER="$(mktemp)"
+trap 'rm -f "$MARKER"' EXIT
+
+set +e
 if [ $# -gt 0 ]; then
   (cd "$SCRIPT_DIR" && uv run python -m pytest -m eval -v "$@")
 else
   (cd "$SCRIPT_DIR" && uv run python -m pytest tests/test_evals.py -m eval -v)
 fi
+PYTEST_EXIT=$?
+set -e
+
+# A shot that dies before reaching the API produces no scored result, but pytest
+# exits non-zero either way -- so a caller counting exit codes reports a crash and a
+# real scenario failure identically. That is how "5 shot(s); 5 did not pass" was
+# reported for a harness that never called the API once (#131 Step 0). Distinguish
+# them here, where the reports are, rather than leaving every caller to guess.
+NEW_REPORTS=$(find "$SCRIPT_DIR/eval/results" -name '*.md' -newer "$MARKER" 2>/dev/null || true)
+
+echo ""
+if [ -z "$NEW_REPORTS" ]; then
+  echo "=== Harness check ==="
+  echo "✗ This run wrote no report at all. Nothing was measured." >&2
+  echo "  Do not read the exit code below as a scenario verdict." >&2
+  exit 2
+fi
+
+echo "=== Harness check ==="
+# shellcheck disable=SC2086
+if ! (cd "$SCRIPT_DIR" && python3 check_eval_ran.py $NEW_REPORTS); then
+  echo "  Exit code 2 means the harness did not run -- distinct from 1, a scenario failure." >&2
+  exit 2
+fi
+
+exit "$PYTEST_EXIT"

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -694,6 +694,83 @@ class TestHookInfrastructure(unittest.TestCase):
             "run-evals.sh does not sync the eval extra, so deepeval/anthropic may be absent",
         )
 
+    def test_ci_mypy_covers_every_top_level_module(self):
+        """CI's mypy invocation must name every top-level module under skill/.
+
+        The invocation is a hand-maintained list, so a new module is type-checked only if
+        someone remembers to widen it. build.py went unchecked until #126 noticed, and
+        check_changelog.py was never added at all -- it shipped in #134 having been run
+        only locally. Both are the same slip: a gate whose coverage silently fails to grow
+        with the code it guards.
+        """
+        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text()
+        mypy_line = next(
+            (line for line in workflow.splitlines() if "mypy" in line and "run:" in line), ""
+        )
+        self.assertTrue(mypy_line, "no mypy invocation found in test.yml")
+
+        modules = sorted(
+            p.name for p in CLAUDE_SKILL_DIR.glob("*.py") if not p.name.startswith("_")
+        )
+        self.assertTrue(modules, "no top-level modules found to check")
+        for module in modules:
+            with self.subTest(module=module):
+                self.assertIn(
+                    module,
+                    mypy_line,
+                    f"{module} exists under skill/ but is absent from CI's mypy invocation, "
+                    "so it is never type-checked in CI",
+                )
+
+    def test_run_evals_script_distinguishes_a_dead_harness(self):
+        """run-evals.sh must classify "nothing was measured" apart from "a scenario failed".
+
+        A shot that dies before reaching the API produces no scored result, but pytest
+        exits non-zero either way -- so a caller counting exit codes reports a crash and
+        a genuine failure identically. That is how "5 shot(s); 5 did not pass" came to be
+        reported for a harness that never called the API once (#131 Step 0), reading
+        exactly like a confirmed hypothesis.
+        """
+        script = (CLAUDE_SKILL_DIR / "run-evals.sh").read_text()
+        self.assertIn(
+            "check_eval_ran.py",
+            script,
+            "run-evals.sh does not check whether the harness actually produced a verdict, "
+            "so a crash and a scenario failure are indistinguishable in its exit code",
+        )
+        self.assertIn(
+            "-newer",
+            script,
+            "the check must be scoped to reports from THIS run; eval/results/ accumulates, "
+            "so an earlier scored report would mask a run that scored nothing",
+        )
+
+    def test_eval_workflow_separates_harness_errors_from_failures(self):
+        """evals.yml must count a dead harness separately from a failing scenario.
+
+        run-evals.sh exits 2 when it produced no verdict and 1 when a scenario genuinely
+        failed. The workflow has to act on that distinction; counting every non-zero exit
+        as "did not pass" is the wording that made a harness which never called the API
+        report "5 shot(s); 5 did not pass" and read as a confirmed hypothesis.
+
+        Asserting on the exit code rather than on the word "harness": the word already
+        appeared in an unrelated warning string, so a keyword check passed vacuously.
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "evals.yml"
+        content = workflow.read_text()
+        self.assertIn(
+            "harness_errors",
+            content,
+            "evals.yml does not track harness errors separately from scenario failures, "
+            "so a run that measured nothing is reported as a run that measured failure",
+        )
+        self.assertIn(
+            "-eq 2",
+            content,
+            "evals.yml does not branch on run-evals.sh's exit code 2, which is how a "
+            "harness that produced no verdict is signalled",
+        )
+
     def test_run_evals_script_uses_eval_marker(self):
         script = CLAUDE_SKILL_DIR / "run-evals.sh"
         if not script.exists():

--- a/skill/tests/test_eval_ran.py
+++ b/skill/tests/test_eval_ran.py
@@ -1,0 +1,128 @@
+"""Tests for distinguishing "the harness never ran" from "the scenario failed".
+
+A shot that dies before reaching the API -- a missing build artifact, an absent
+API key, a network failure -- produces no scored result, but the runner's exit
+code is non-zero either way. Reported as a count, "did not pass" is then
+indistinguishable from the model actually failing the scenario.
+
+This is not hypothetical. The first eval run of #131's Step 0 reported
+"5 shot(s); 5 did not pass" from a harness that never called the API once, and it
+read exactly like a confirmed hypothesis. eval/README.md's whole thesis is that a
+broken eval is self-sealing: nothing downstream contradicts it.
+
+The reporter already holds the evidence -- a crashed shot writes a report whose
+Summary table has a header, a separator, and no data rows -- so this is a pure
+function over report text. It deliberately needs no API key, no network and no
+live run, because it must work in exactly the conditions where the harness cannot.
+"""
+
+import unittest
+
+from check_eval_ran import _read_reports, check_run, scored_scenarios
+
+HEADER = (
+    "# PDCA Eval Report — 2026-09-08 15:33:00\n\n"
+    "## Summary\n\n"
+    "| Scenario | Phase | Score | Threshold | GEval | Mechanical |\n"
+    "|----------|-------|-------|-----------|-------|------------|\n"
+)
+
+EMPTY_REPORT = HEADER + "\n## Scenario Details\n"
+
+SCORED_REPORT = (
+    HEADER
+    + "| 2-superpowers-branch-finish | TDD Implementation | 0.90 | 0.50 | ✅ | ✅ |\n"
+    + "\n## Scenario Details\n"
+)
+
+TWO_SCORED = (
+    HEADER
+    + "| 2-first-step | TDD Implementation | 1.00 | 0.50 | ✅ | ✅ |\n"
+    + "| 2-after-passing-test | TDD Implementation | 0.40 | 0.50 | ❌ | ✅ |\n"
+    + "\n## Scenario Details\n"
+)
+
+
+class TestScoredScenarios(unittest.TestCase):
+    def test_empty_report_has_no_scored_scenarios(self):
+        """The signature of a shot that died before the API."""
+        self.assertEqual(scored_scenarios(EMPTY_REPORT), [])
+
+    def test_scored_report_names_its_scenario(self):
+        self.assertEqual(scored_scenarios(SCORED_REPORT), ["2-superpowers-branch-finish"])
+
+    def test_multiple_rows_all_counted(self):
+        self.assertEqual(scored_scenarios(TWO_SCORED), ["2-first-step", "2-after-passing-test"])
+
+    def test_a_failing_score_still_counts_as_scored(self):
+        """A red verdict is a measurement. Only the absence of one is not."""
+        self.assertIn("2-after-passing-test", scored_scenarios(TWO_SCORED))
+
+    def test_separator_row_is_not_a_scenario(self):
+        self.assertEqual(scored_scenarios(HEADER), [])
+
+    def test_text_without_a_summary_table_scores_nothing(self):
+        self.assertEqual(scored_scenarios("not a report at all"), [])
+
+
+class TestCheckRun(unittest.TestCase):
+    def test_reports_with_scores_pass(self):
+        self.assertEqual(check_run([SCORED_REPORT]), [])
+
+    def test_shots_that_scored_nothing_are_a_harness_error(self):
+        problems = check_run([EMPTY_REPORT, EMPTY_REPORT])
+        self.assertTrue(problems)
+        joined = " ".join(problems)
+        self.assertIn("did not run", joined)
+        self.assertNotIn("did not pass", joined)
+
+    def test_no_reports_at_all_is_a_harness_error(self):
+        problems = check_run([])
+        self.assertTrue(problems)
+        self.assertIn("no report", " ".join(problems).lower())
+
+    def test_one_scored_among_several_empty_is_not_a_harness_error(self):
+        """A partial run still measured something; that is a scenario result, not a crash."""
+        self.assertEqual(check_run([EMPTY_REPORT, SCORED_REPORT]), [])
+
+    def test_problem_message_does_not_imply_a_verdict(self):
+        """The failure text must not read like the model failed the scenario.
+
+        "scored scenario" is fine and necessary -- the absence of a score is the
+        whole signal. What must not appear is language asserting an outcome the
+        run never produced.
+        """
+        joined = " ".join(check_run([EMPTY_REPORT])).lower()
+        for verdict_phrase in ("failed the scenario", "did not pass", "scenario failed"):
+            self.assertNotIn(verdict_phrase, joined)
+        self.assertIn("did not run", joined)
+
+
+class TestReadReports(unittest.TestCase):
+    """Callers must be able to pass only this run's reports.
+
+    eval/results/ accumulates across runs, so passing the whole directory would let a
+    previously scored report mask a current run that scored nothing -- exactly the
+    stale-artifact hazard that made a build look correct by accident in #114.
+    """
+
+    def test_reads_a_directory_and_a_single_file(self):
+        import tempfile
+        from pathlib import Path as P
+
+        with tempfile.TemporaryDirectory() as d:
+            root = P(d)
+            (root / "a.md").write_text(SCORED_REPORT)
+            (root / "b.md").write_text(EMPTY_REPORT)
+
+            self.assertEqual(len(_read_reports([str(root)])), 2)
+            self.assertEqual(_read_reports([str(root / "b.md")]), [EMPTY_REPORT])
+            # only the empty one -> harness error, despite a scored sibling on disk
+            self.assertTrue(check_run(_read_reports([str(root / "b.md")])))
+
+    def test_missing_path_is_ignored_not_fatal(self):
+        self.assertEqual(_read_reports(["/nonexistent/path.md"]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The mechanism the #139 review said should have been built instead of a reminder.

## The defect

A shot that dies before reaching the API — missing build artifact, absent key, network failure — produces **no scored result**. But pytest exits non-zero either way, so anything counting exit codes reports a crash and a genuine scenario failure identically.

Not hypothetical. The first eval run of #131's Step 0 reported:

```
Completed 5 shot(s); 5 did not pass.
```

from a harness that **never called the API once**. It read exactly like a confirmed hypothesis and would have justified a master-prompt change on no evidence. A second run then reported `2 did not pass` with the reports unreachable. Two consecutive numbers, neither a measurement.

`eval/README.md` states why this class is dangerous: a broken eval is self-sealing, because the eval *is* the mechanism meant to notice.

## The fix

`skill/check_eval_ran.py`. The evidence was already there — a crashed shot leaves a Summary table with a header, a separator, and **no data rows**. So the check is a pure function over report text, needing no API key, no network, and no live run.

That's deliberate: **it has to work in exactly the conditions where the harness cannot.**

- `run-evals.sh` exits **2** when nothing was measured, distinct from **1** for a real scenario failure.
- It scopes the check to reports newer than a marker created at the start of the run. `eval/results/` accumulates, so passing the whole directory would let an earlier scored report mask a run that scored nothing — the same stale-artifact hazard `BUILD.md` documents for the build.
- `evals.yml` counts the two separately and fails loudly on a harness error rather than folding it into a "did not pass" tally.

## Demonstrated without an API key

| Input | Result |
|---|---|
| Reports written, nothing scored (the real dead-run signature) | exit 1 — *"the harness did not run to completion. Nothing was measured."* |
| No report at all | exit 1 — *"produced no report at all"* |
| A scored report, **including a RED verdict** | exit 0 |

That last row is the important one: a red verdict *is* a measurement. Only its absence isn't.

## Called shots

- `tests/test_eval_ran.py` → `ModuleNotFoundError: No module named 'check_eval_ran'`
- `test_ci_mypy_covers_every_top_level_module` → `check_changelog.py` absent from CI's mypy invocation

## Two corrections made rather than shipped

**A test of mine passed vacuously.** `test_eval_workflow_separates_harness_errors_from_failures` first asserted the word "harness" appeared in `evals.yml` — which it already did, in an unrelated warning string. A guard that couldn't fail, in the PR whose subject is guards that can't fail. Rewritten to assert the exit-code branch, which produced a genuine RED.

**An assertion of mine over-reached.** I forbade the substring `"score"` in the error message, which wrongly rejects *"scored scenario"* — the necessary vocabulary. Narrowed to phrasings that actually imply a verdict.

## An unrelated gap this surfaced

**`check_changelog.py` was never added to CI's mypy invocation.** It shipped in #134 having been type-checked only locally, and has been unchecked in CI ever since. `build.py` had the identical gap until #126.

The new test asserts every top-level module under `skill/` appears in that hand-maintained list, so coverage can't silently fail to grow with the code a third time. It caught `check_changelog.py` on its first run.

## Verification

```
195 passed, 180 subtests passed
mypy clean across 28 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_