### PR TITLE
The pre-commit mypy hook could never run outside one machine

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "statusMessage": "Running mypy before commit...",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"' 2>/dev/null); echo \"$cmd\" | grep -qE 'git commit' || exit 0; cd '/Users/kenjudy/Library/Mobile Documents/iCloud~md~obsidian/Documents/PDCA Process/skill' && uv run mypy eval tests/test_build.py 2>&1 | python3 -c \"import sys, json; output = sys.stdin.read().strip(); print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','additionalContext':'mypy (advisory — commit will proceed):\\n' + output}})) if output else None\"; exit 0"
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"' 2>/dev/null); echo \"$cmd\" | grep -qE 'git commit' || exit 0; root=\"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}\"; [ -n \"$root\" ] && [ -x \"$root/skill/typecheck.sh\" ] || { echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"mypy hook skipped: could not locate skill/typecheck.sh from this directory.\"}}'; exit 0; }; output=$(bash \"$root/skill/typecheck.sh\" 2>&1 || true); printf '%s' \"$output\" | python3 -c \"import sys, json; o = sys.stdin.read().strip(); print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse','additionalContext':'mypy (advisory \u2014 commit will proceed):\\n' + o}})) if o else None\"; exit 0"
           }
         ]
       }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: skill
 
       - name: Type check (mypy)
-        run: uv run mypy eval tests build.py check_changelog.py check_eval_ran.py check_release_version.py
+        run: bash typecheck.sh
         working-directory: skill
 
       - name: Build and test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@
 - **`evals.yml` counts the two separately** and fails loudly on a harness error rather
   than folding it into a "did not pass" tally.
 
+### Bug Fixes
+
+- **The pre-commit mypy hook had never been able to run on any machine but one.**
+  `.claude/settings.json` is checked in, and its `PreToolUse` hook `cd`-ed to an absolute
+  path under one contributor's home directory. Everywhere else the `cd` failed, the `&&`
+  chain short-circuited, and the trailing `exit 0` reported success — an advisory gate
+  that looked configured to everyone and could fire for no one. Found during a review of
+  #139, and a better instance of that PR's own subject than the PR contained.
+- **`skill/typecheck.sh` is now the single mypy invocation**, called by both CI and the
+  hook. They previously held separate argument lists and had already diverged: the hook
+  named `eval tests/test_build.py` while CI named six targets. That is #114 in miniature —
+  two copies of one procedure drifting silently because only one of them ever ran.
+- The hook now resolves the repository from `CLAUDE_PROJECT_DIR`, falling back to
+  `git rev-parse`, and **reports explicitly when it cannot locate the script** rather than
+  skipping in silence. `test_settings_json_has_no_machine_specific_path` asserts no
+  home-directory path returns.
+
 ### Optional superpowers interop (#131)
 
 - The pdca-framework skill now offers optional interoperation with

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -694,20 +694,60 @@ class TestHookInfrastructure(unittest.TestCase):
             "run-evals.sh does not sync the eval extra, so deepeval/anthropic may be absent",
         )
 
-    def test_ci_mypy_covers_every_top_level_module(self):
-        """CI's mypy invocation must name every top-level module under skill/.
+    def test_settings_json_has_no_machine_specific_path(self):
+        """.claude/settings.json is checked in, so it must run on every clone.
 
-        The invocation is a hand-maintained list, so a new module is type-checked only if
-        someone remembers to widen it. build.py went unchecked until #126 noticed, and
+        Its PreToolUse hook contained an absolute path to one contributor's Mac. On any
+        other machine the `cd` fails, the `&&` chain short-circuits, and the trailing
+        `exit 0` reports success -- an advisory mypy gate that has never been able to fire
+        anywhere but one laptop, while looking configured to everyone.
+        """
+        settings = REPO_ROOT / ".claude" / "settings.json"
+        self.assertTrue(settings.exists(), ".claude/settings.json missing")
+        content = settings.read_text()
+        for home_prefix in ("/Users/", "/home/", "C:\\Users"):
+            with self.subTest(prefix=home_prefix):
+                self.assertNotIn(
+                    home_prefix,
+                    content,
+                    f"settings.json hardcodes a machine-specific path containing "
+                    f"'{home_prefix}'. It is checked in, so it must resolve paths relative "
+                    "to the repository -- otherwise the hook silently no-ops for everyone else",
+                )
+
+    def test_typecheck_invocation_is_shared(self):
+        """CI and the pre-commit hook must type-check via one shared script.
+
+        They previously carried separate mypy argument lists and had already diverged --
+        the hook still named `tests/test_build.py` while CI named six targets. That is
+        #114 in miniature: two copies of one procedure, drifting silently because only one
+        of them ever ran.
+        """
+        script = CLAUDE_SKILL_DIR / "typecheck.sh"
+        self.assertTrue(script.exists(), "skill/typecheck.sh missing -- no shared invocation")
+
+        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text()
+        self.assertIn("typecheck.sh", workflow, "CI does not use the shared typecheck script")
+
+        settings = (REPO_ROOT / ".claude" / "settings.json").read_text()
+        self.assertIn(
+            "typecheck.sh",
+            settings,
+            "the pre-commit hook does not use the shared typecheck script, so its module "
+            "list can drift from CI's again",
+        )
+
+    def test_ci_mypy_covers_every_top_level_module(self):
+        """typecheck.sh must name every top-level module under skill/.
+
+        The list is hand-maintained, so a new module is type-checked only if someone
+        remembers to widen it. build.py went unchecked until #126 noticed, and
         check_changelog.py was never added at all -- it shipped in #134 having been run
         only locally. Both are the same slip: a gate whose coverage silently fails to grow
-        with the code it guards.
+        with the code it guards. Asserted against typecheck.sh rather than the workflow,
+        since that script is now the single invocation CI and the hook both call.
         """
-        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text()
-        mypy_line = next(
-            (line for line in workflow.splitlines() if "mypy" in line and "run:" in line), ""
-        )
-        self.assertTrue(mypy_line, "no mypy invocation found in test.yml")
+        invocation = (CLAUDE_SKILL_DIR / "typecheck.sh").read_text()
 
         modules = sorted(
             p.name for p in CLAUDE_SKILL_DIR.glob("*.py") if not p.name.startswith("_")
@@ -717,9 +757,9 @@ class TestHookInfrastructure(unittest.TestCase):
             with self.subTest(module=module):
                 self.assertIn(
                     module,
-                    mypy_line,
-                    f"{module} exists under skill/ but is absent from CI's mypy invocation, "
-                    "so it is never type-checked in CI",
+                    invocation,
+                    f"{module} exists under skill/ but is absent from typecheck.sh, so it "
+                    "is never type-checked -- by CI or by the pre-commit hook",
                 )
 
     def test_run_evals_script_distinguishes_a_dead_harness(self):

--- a/skill/typecheck.sh
+++ b/skill/typecheck.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Single source of truth for what mypy checks.
+#
+# CI and the pre-commit hook in .claude/settings.json both call this. They
+# previously carried separate argument lists and had already drifted -- the hook
+# named `eval tests/test_build.py` while CI named six targets -- which is #114 in
+# miniature: two copies of one procedure diverging silently because only one of
+# them ever ran.
+#
+# tests/test_build.py::test_ci_mypy_covers_every_top_level_module asserts that every
+# top-level module under skill/ appears below, so coverage cannot quietly fail to
+# grow with the code. build.py went unchecked until #126 and check_changelog.py was
+# never added at all until #141 -- both the same slip.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR"
+exec uv run --locked mypy \
+  eval \
+  tests \
+  build.py \
+  check_changelog.py \
+  check_eval_ran.py \
+  check_release_version.py \
+  "$@"


### PR DESCRIPTION
Found during the review of #139, and a better instance of that PR's own subject than the PR contained.

## The defect

`.claude/settings.json` is **checked into the repository**, and its `PreToolUse` hook began:

```bash
cd '/Users/kenjudy/Library/Mobile Documents/iCloud~md~obsidian/Documents/PDCA Process/skill' && uv run mypy ...
```

On any other machine the `cd` fails, the `&&` chain short-circuits, and the trailing `exit 0` reports success.

**An advisory mypy gate that looked configured to every contributor and was capable of firing for exactly one.** That is this repository's defining failure class, sitting in its own configuration.

## A second defect underneath it

The hook and CI held **separate mypy argument lists, already diverged**:

| | targets |
|---|---|
| hook | `eval tests/test_build.py` |
| CI | `eval tests build.py check_changelog.py check_eval_ran.py check_release_version.py` |

Two copies of one procedure drifting silently because only one of them ever ran — #114 in miniature. `skill/typecheck.sh` is now the single invocation both call.

## The part that actually matters

The fix isn't the corrected path. It's that **an unresolvable repository root now says so**:

```
{"hookSpecificOutput": {..., "additionalContext":
  "mypy hook skipped: could not locate skill/typecheck.sh from this directory."}}
```

The original defect was never "wrong path". It was that a wrong path was *indistinguishable from success*.

## Called shots

- `test_settings_json_has_no_machine_specific_path` → `'/Users/' unexpectedly found in ...`
- `test_typecheck_invocation_is_shared` → `skill/typecheck.sh missing -- no shared invocation`

## Demonstrated end to end

| Input | Result |
|---|---|
| Non-commit command | exits early, no output |
| `git commit`, clean tree | runs shared typecheck, reports `Success: no issues found in 28 source files` |
| `git commit` from an unrelated cwd, no `CLAUDE_PROJECT_DIR` | explicit *"hook skipped: could not locate..."* |

**The hook fired live during this session** — visible in the tool output while I was working. It could not have done that before this change.

## Also

`test_ci_mypy_covers_every_top_level_module` retargeted from the workflow's inline mypy line to `typecheck.sh`, following the source of truth. It still asserts every top-level module under `skill/` appears in the invocation — the guard that caught `check_changelog.py` in #141.

## Verification

```
197 passed, 183 subtests passed
mypy clean across 28 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_