### PR TITLE
CLAUDE.md and AGENTS.md gave opposite instructions on pushing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ bd sync               # Sync with git
 
 **CRITICAL RULES:**
 - Do NOT push without explicit human instruction ("go ahead and push", "push it", etc.)
+- The single exception: when the operator has explicitly instructed you to act
+  autonomously for this session, push without waiting. Absent that instruction, the
+  human-in-the-loop default above applies.
 - Present git status and the proposed push command; wait for a clear go-ahead
 - If push fails, report the error and wait for human direction before retrying
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@
   skipping in silence. `test_settings_json_has_no_machine_specific_path` asserts no
   home-directory path returns.
 
+### Bug Fixes
+
+- **`CLAUDE.md` and `AGENTS.md` gave opposite instructions on pushing.** Both are
+  auto-loaded agent instruction files — `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex
+  — and on the most consequential action either agent takes they disagreed outright:
+  `CLAUDE.md` said *"NEVER say 'ready to push when you are' — push yourself"*, while
+  `AGENTS.md` said *"Do NOT push without explicit human instruction"*. Nothing could detect
+  the divergence, since each file is only ever read by the agent it governs.
+- Both now state the same policy: **the operator approves the push in a human-in-the-loop
+  session, and an agent pushes on its own initiative only when explicitly instructed to act
+  autonomously.** `CLAUDE.md`'s Session Completion sequence gains an approval step;
+  `AGENTS.md` gains the autonomous carve-out it lacked.
+- `test_push_policy_is_consistent_across_agent_files` asserts both halves appear in both
+  files, so dropping either one — or reintroducing an unconditional self-push instruction —
+  now fails the suite.
+
 ### Optional superpowers interop (#131)
 
 - The pdca-framework skill now offers optional interoperation with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,16 +127,24 @@ Work is **not complete** until `git push` succeeds and the human has signed off 
 1. File beads issues for any remaining work
 2. Run quality gates if code changed: `cd skill && bash run-tests.sh`
 3. Close finished issues, update in-progress ones
-4. Push:
+4. **Prepare the push and get approval** — stage, commit, then show the operator what
+   would be pushed and wait:
    ```bash
    git pull --rebase
    bd sync
-   git push
-   git status  # must show "up to date with origin"
+   git status  # show the operator exactly what will be pushed
    ```
-5. Hand off — provide context for next session
+5. **Push once approved** — `git push`, then `git status` must show "up to date with origin"
+6. Hand off — provide context for next session
 
-**NEVER** say "ready to push when you are" — push yourself. If push fails, resolve and retry.
+**Pushing is the operator's call.** In a human-in-the-loop session, present the committed
+work and wait for a clear go-ahead ("push it", "go ahead and push"). Push on your own
+initiative **only** when explicitly instructed to act autonomously. If an approved push
+fails, resolve and retry rather than handing back a broken state.
+
+This matches `AGENTS.md`, which governs Codex sessions. The two files previously gave
+opposite instructions here, and `tests/test_build.py::test_push_policy_is_consistent_across_agent_files`
+now asserts they cannot diverge again.
 
 ## Planning Discipline
 

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -694,6 +694,42 @@ class TestHookInfrastructure(unittest.TestCase):
             "run-evals.sh does not sync the eval extra, so deepeval/anthropic may be absent",
         )
 
+    def test_push_policy_is_consistent_across_agent_files(self):
+        """CLAUDE.md and AGENTS.md must agree on when an agent may push.
+
+        Both are auto-loaded instruction files -- CLAUDE.md by Claude Code, AGENTS.md by
+        Codex -- and they gave opposite directives on the most consequential action either
+        takes. CLAUDE.md said "NEVER say 'ready to push when you are' -- push yourself";
+        AGENTS.md said "Do NOT push without explicit human instruction". Nothing could
+        detect the divergence, because each file is only ever read by the agent it governs.
+
+        The policy is: the operator approves the push in a human-in-the-loop session, and
+        an agent pushes on its own only when explicitly instructed to act autonomously.
+        Both halves must appear in both files, so dropping either one fails here.
+        """
+        for name in ("CLAUDE.md", "AGENTS.md"):
+            content = (REPO_ROOT / name).read_text()
+            lowered = content.lower()
+            # assertTrue rather than assertIn: assertIn renders the entire file into the
+            # failure message, which buries the one sentence that matters.
+            with self.subTest(file=name, half="approval default"):
+                self.assertTrue(
+                    "approv" in lowered,
+                    f"{name} does not state that pushing requires operator approval by default",
+                )
+            with self.subTest(file=name, half="autonomous carve-out"):
+                self.assertTrue(
+                    "autonomous" in lowered,
+                    f"{name} does not state the exception -- an agent pushes on its own only "
+                    "when explicitly instructed to act autonomously",
+                )
+            with self.subTest(file=name, half="no unconditional self-push"):
+                self.assertFalse(
+                    "push yourself" in lowered,
+                    f"{name} instructs unconditional self-push, contradicting the approval "
+                    "default and the other agent instruction file",
+                )
+
     def test_settings_json_has_no_machine_specific_path(self):
         """.claude/settings.json is checked in, so it must run on every clone.
 


### PR DESCRIPTION
The third and sharpest finding from the Opus review of #139.

## The contradiction

Both files are **auto-loaded agent instructions** — `CLAUDE.md` for Claude Code, `AGENTS.md` for Codex — and on the most consequential action either agent takes, they disagreed outright:

| | |
|---|---|
| `CLAUDE.md:139` | "**NEVER** say 'ready to push when you are' — **push yourself**." |
| `AGENTS.md:35` | "**Do NOT push** without explicit human instruction" |

Nothing could detect this, because **each file is only ever read by the agent it governs**. An agent following one is correct by its own instructions and wrong by the repository's, with no surface where the conflict becomes visible.

## The policy

As stated by the operator:

> **Pushing is the operator's call.** In a human-in-the-loop session, present the committed work and wait for a clear go-ahead. Push on your own initiative **only** when explicitly instructed to act autonomously.

`CLAUDE.md`'s Session Completion sequence gains an approval step and drops the self-push directive. `AGENTS.md` already had the HITL half but lacked the autonomous carve-out, so it gains that.

## This defect had a live cost

Acting on `CLAUDE.md`, **I pushed unilaterally throughout the session that found this** — dozens of times, without presenting a diff for approval. The instruction was wrong and I followed it.

That is what a contradiction between two governing files produces, and it's why this is worth more than the reminder in #139 that I closed: the repository's rule existed, was correct in one file, and was actively overridden in the other.

This PR was itself committed and then **held unpushed** until approved, which is the first time the corrected policy was exercised.

## Called shot

`test_push_policy_is_consistent_across_agent_files` → `CLAUDE.md does not state that pushing requires operator approval by default`, and `...does not state the exception`.

It asserts **both halves appear in both files**, so dropping either — or reintroducing an unconditional self-push instruction — fails the suite.

Also switched those assertions from `assertIn`/`assertNotIn` to `assertTrue`/`assertFalse`: `assertIn` renders the entire instruction file into the failure message, burying the one sentence that matters.

## Verification

```
198 passed, 189 subtests passed
```

## Context

The #139 retrospective produced three mechanisms rather than the prose it proposed: #141 (the harness cannot report a dead run as a failure), #142 (the pre-commit hook could never run outside one machine), and this. #139 is closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_