### PR TITLE
docs: add Partial-Instance Coverage testing anti-pattern

### DIFF
--- a/2. Do/2. Test Drive the Change.md
+++ b/2. Do/2. Test Drive the Change.md
@@ -126,6 +126,7 @@ If production evidence (logs, metrics) proves a bug exists but unit tests pass:
 - [ ] Linting passes (check githooks, makefile, or package.json/project files for configured tools) ✅
 - [ ] Compilation/build succeeds ✅
 - [ ] All quality gates pass (type checks, format checks, etc.) ✅
+- [ ] If this task's acceptance criteria makes a whole-flow/whole-file claim, does a test exercise the complete thing — not just the edited piece? See `references/testing-anti-patterns.md` #8. ✅
 - [ ] Commit message ready
 
 **Next:** What's the next smallest testable piece?

--- a/2. Do/Testing Anti-Patterns.md
+++ b/2. Do/Testing Anti-Patterns.md
@@ -78,6 +78,18 @@ Starting with the happy-path test can force the stub to grow into a full impleme
 
 ---
 
+## 8. Partial-Instance Coverage
+
+Testing the first edited instance of a repeated assumption -- one step of a multi-step flow, one file of a documented multi-file change, one command of a multi-command sequence -- and treating the task as done, when the task's own acceptance criteria makes a whole-flow or whole-file claim ("operator can run X end-to-end," "stage Y now supports Z").
+
+*Diagnosis:* The acceptance criteria's claim is broader than what the tests actually exercise. Each individual test passes; the claim the criteria makes has never been tested as a whole.
+
+*Rule:* Before closing, grep the full scope named in the acceptance criteria for every other instance of the assumption just removed or changed -- not just the one instance you edited. If the plan describes a multi-step operator flow (e.g., run command A, then conditionally run command B), write a test that exercises the full sequence, not just each command in isolation.
+
+*Origin:* Found via adversarial review after a fix shipped that added a mode-override flag but tested only the single-command cases (set mode, auto-detect mode, explicit-flag-overrides-detection) -- never the two-command sequence (detect, then re-run to override) the design actually specified. A sibling fix split a multi-step file's Step 1 for two modes, tested Step 1, and closed the task -- Steps 2-6 of the same file still assumed the removed constraint. Both were caught by a fresh critic reading the whole file/flow, not by the tests written during Do.
+
+---
+
 ## Quick Check Before Committing
 
 - [ ] Every assertion is on real behavior, not mock call counts
@@ -85,3 +97,4 @@ Starting with the happy-path test can force the stub to grow into a full impleme
 - [ ] Mock responses mirror the full real API shape
 - [ ] No production methods exist solely for test access
 - [ ] Every test watched fail before watching it pass
+- [ ] If the acceptance criteria makes a whole-flow/whole-file claim, a test exercises the complete thing -- not just the edited piece (see #8)

--- a/3. Check/3. Completeness Check.md
+++ b/3. Check/3. Completeness Check.md
@@ -32,6 +32,7 @@ Review our original goal outcome and plan against our execution.
 - [ ] Test coverage is adequate and appropriate
 - [ ] No untested implementation was committed
 - [ ] Simple test scenarios were effective
+- [ ] For any acceptance criteria with an end-to-end/completeness claim, was that claim itself re-verified as a whole — not just each edited file individually? (an adversarial critic pass, or a fresh re-read of the full scope named in the claim; see `references/testing-anti-patterns.md` #8)
 
 
 **Structural Review:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Documentation (#144)
+
+- Added anti-pattern #8 (Partial-Instance Coverage) to `testing-anti-patterns.md`: testing
+  the first edited instance of a repeated assumption (one step of a multi-step flow, one
+  file of a documented multi-file change) and closing the task, when the acceptance
+  criteria makes a whole-flow or whole-file claim. Found via a retrospective on a downstream
+  project where two fixes each passed their own tests but left the stated end-to-end claim
+  untested as a whole -- caught only by a fresh adversarial critic reading the whole
+  file/flow, not by Do-phase tests or the Check phase that followed.
+- Added matching checklist lines: `do-prompts.md`'s "Ready for commit?" and
+  `check-prompts.md`'s "Process Audit" both now point back to anti-pattern #8.
+
 ### Optional superpowers interop (#131)
 
 - The pdca-framework skill now offers optional interoperation with


### PR DESCRIPTION
## Summary

- Adds anti-pattern #8 (Partial-Instance Coverage) to the Testing Anti-Patterns reference: testing the first edited instance of a repeated assumption (one step of a multi-step flow, one file of a documented multi-file change) and closing the task, when the acceptance criteria makes a whole-flow/whole-file claim.
- Adds a matching Do-phase "Ready for commit?" checklist line and a Check-phase "Process Audit" checklist line pointing back to it.

## Why

Found during a retrospective on a separate project (agentic-pdlc). Two fixes each passed their own tests but left the task's stated acceptance-criteria claim untested as a whole:
- A mode-override flag was tested per-command (set mode, auto-detect, explicit-flag-overrides-detection) but never as the two-command sequence the design specified (detect, then re-run to override) -- the override silently discarded itself.
- A multi-step stage file got greenfield handling for Step 1 only; the task closed with Steps 2-6 still assuming the removed constraint.

Both were caught by a fresh adversarial critic reading the whole file/flow, not by the tests written during Do or by the Check phase that followed -- because neither checklist asked whether the acceptance criteria's own end-to-end claim had been verified as a whole.

## Test plan

- [x] Master files edited: `2. Do/Testing Anti-Patterns.md`, `2. Do/2. Test Drive the Change.md`, `3. Check/3. Completeness Check.md`
- [x] `./build-skill.sh` regenerates `skill/pdca-framework/references/{testing-anti-patterns,do-prompts,check-prompts}.md` correctly from the updated masters
- [x] `bash run-tests.sh` -- 179 passed, 176 subtests passed
- [x] `git status` after build shows only the 3 master files changed, no generated build artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)