### PR TITLE
Eval reports record the dependency versions that produced them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,12 @@ jobs:
       - name: Eval harness import smoke test
         run: uv run --locked python -m pytest tests/test_eval_imports.py -v
         working-directory: skill
+
+      # The reporter records the installed deepeval and anthropic versions into every
+      # report, so a report can be used as a baseline (issue #122). The default suite
+      # installs neither package, so there those assertions only ever exercise the
+      # "not installed" branch. Running them here, with the eval extra synced, is the
+      # only place the real version-recording path executes. No API calls.
+      - name: Reporter provenance against installed eval dependencies
+        run: uv run --locked python -m pytest tests/test_evals_reporter.py -v
+        working-directory: skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,18 @@
   Unreleased` section exists, which stays true forever after one entry and is blind to the
   PR that forgot. Dependabot is exempt — its bumps are summarised once at release time.
 
+- **Eval reports now record the dependency versions that produced them.** Every report
+  gains an `**Environment:**` line naming the installed `deepeval` and `anthropic`
+  versions, read via `importlib.metadata` so the reporter stays importable without the
+  eval extra. Reports previously carried a timestamp and nothing else, which is why #122
+  — did the `deepeval` 3.9.9 → 4.x bump change how scenarios score? — turned out to be
+  unanswerable in retrospect: no run on record could be attributed to a version, so there
+  was no before-state to compare against. This is what makes the *next* major bump
+  answerable without anyone remembering to write it down. `tests/test_evals_reporter.py`
+  now also runs in CI's `eval-imports` job: the default suite installs neither package, so
+  there the provenance assertions only ever exercise the "not installed" branch, and the
+  path that produces the string a human actually reads would run nowhere.
+
 ## v1.3.0 (2026-08-18)
 
 > **Windows builders:** `build-skill.ps1` now requires a Python 3 interpreter on `PATH` as

--- a/skill/eval/reporter.py
+++ b/skill/eval/reporter.py
@@ -1,7 +1,28 @@
 """EvalReporter: collects scenario results and writes a Markdown report."""
 
+import importlib.metadata
 import textwrap
 from pathlib import Path
+
+# Recorded in every report. A report that does not say what produced it cannot serve
+# as a baseline: issue #122 asked whether deepeval 3.9.9 -> 4.x changed scenario
+# scoring, and the question was unanswerable because every report on record carried a
+# timestamp and nothing else. No run could be attributed to a version.
+PROVENANCE_PACKAGES = ("deepeval", "anthropic")
+
+
+def _installed_version(package: str) -> str:
+    """Version of an installed distribution, without importing it.
+
+    importlib.metadata reads distribution metadata off disk, so the reporter stays
+    importable in the default unit suite, which installs neither of these. "not
+    installed" is recorded rather than omitted -- a missing line reads as an older
+    report format, while an explicit one records that the package genuinely was absent.
+    """
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return "not installed"
 
 
 def compute_shot_stats(shot_scores: list[float]) -> dict:
@@ -46,6 +67,11 @@ class EvalReporter:
 
         from datetime import datetime
         lines.append(f"# PDCA Eval Report — {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+
+        # Before the results, not after: this is the line that tells a reader whether
+        # the scores below are comparable to the ones they are comparing them against.
+        versions = ", ".join(f"{p}: {_installed_version(p)}" for p in PROVENANCE_PACKAGES)
+        lines.append(f"**Environment:** {versions}\n")
 
         # Summary table
         lines.append("## Summary\n")

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -910,6 +910,25 @@ class TestHookInfrastructure(unittest.TestCase):
             "fail on a missing deepeval rather than testing anything",
         )
 
+    def test_ci_exercises_the_reporter_against_installed_eval_dependencies(self):
+        """The eval-extra job must also run the reporter tests.
+
+        The reporter records the installed deepeval and anthropic versions so a report
+        can serve as a baseline (issue #122). The default suite installs neither, so
+        every provenance assertion there exercises only the "not installed" branch. If
+        no job runs those tests with the packages present, the branch that produces the
+        version string a human will actually read is never executed anywhere -- the
+        same shape as the pre-commit hook that could not run outside one machine (#142).
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "test.yml"
+        content = workflow.read_text()
+        self.assertTrue(
+            "tests/test_evals_reporter.py" in content,
+            "no CI job runs tests/test_evals_reporter.py with the eval extra installed, so "
+            "the reporter's real version-recording path is never exercised -- it would only "
+            "ever be tested against absent packages",
+        )
+
     def test_release_workflow_checks_version_consistency(self):
         """release.yml must run check_release_version.py against the tag it is building.
 

--- a/skill/tests/test_evals_reporter.py
+++ b/skill/tests/test_evals_reporter.py
@@ -267,3 +267,63 @@ class TestEvalReporter:
         assert "SHOT1-DISTINCTIVE" in content
         assert "SHOT2-DISTINCTIVE" in content
         assert "SHOT3-DISTINCTIVE" in content
+
+
+class TestReportProvenance:
+    """A report must record the dependency versions that produced it.
+
+    Issue #122 asked whether the `deepeval` 3.9.9 -> 4.x upgrade changed how scenarios
+    score. That question turned out to be unanswerable, and not because the runs were
+    missing: reports carried a timestamp and nothing else, so no recorded run could be
+    attributed to a `deepeval` version. There was no before-state to compare against.
+
+    Recording the versions in the report is what makes the *next* major bump answerable
+    without anyone having to remember to write it down.
+
+    `importlib.metadata.version` reads installed distribution metadata without importing
+    the package, so the reporter stays importable in the default unit suite, which
+    installs neither `deepeval` nor `anthropic`. In that suite these assertions exercise
+    the not-installed path; the `eval-imports` job exercises the real one. Real reports
+    are only ever written by `run-evals.sh`, which syncs the eval extra first.
+    """
+
+    @staticmethod
+    def _installed(name):
+        import importlib.metadata
+
+        try:
+            return importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            return None
+
+    def _report_text(self, tmp_path):
+        reporter = EvalReporter()
+        reporter.add(_make_result())
+        return reporter.write_report(tmp_path / "report.md").read_text()
+
+    def test_report_names_deepeval(self, tmp_path):
+        assert "deepeval" in self._report_text(tmp_path)
+
+    def test_report_names_anthropic(self, tmp_path):
+        assert "anthropic" in self._report_text(tmp_path)
+
+    def test_recorded_deepeval_version_matches_the_installed_one(self, tmp_path):
+        """Catches a hardcoded or stale value, which is the failure that would make
+        the provenance line worse than none at all."""
+        content = self._report_text(tmp_path)
+        installed = self._installed("deepeval")
+        expected = f"deepeval: {installed}" if installed else "deepeval: not installed"
+        assert expected in content
+
+    def test_recorded_anthropic_version_matches_the_installed_one(self, tmp_path):
+        content = self._report_text(tmp_path)
+        installed = self._installed("anthropic")
+        expected = f"anthropic: {installed}" if installed else "anthropic: not installed"
+        assert expected in content
+
+    def test_empty_report_still_records_provenance(self, tmp_path):
+        """A run that scored nothing is exactly the one whose environment is in
+        question -- see #141, where a harness that never called the API reported
+        '5 shot(s); 5 did not pass'."""
+        content = EvalReporter().write_report(tmp_path / "empty.md").read_text()
+        assert "deepeval" in content


### PR DESCRIPTION
First of two PRs for #122. This one is the mechanism; the baseline itself follows separately.

## What #122 turned out to be

#122 asks whether the `deepeval` 3.9.9 → 4.x bump changed how scenarios score. Working the analysis surfaced that **the question is unanswerable in retrospect**, and not for want of runs:

- Every report carried a timestamp and nothing else (`eval/reporter.py:47`), so **no recorded run can be attributed to a `deepeval` version**. There is no before-state to compare against.
- None can be reconstructed either. Before `b1dd568` the lockfile violated the `pyproject` floors, so `uv` re-resolved on every invocation — those runs' actual dependency set is unknowable, not merely unrecorded.
- #122's own closing procedure — *"compare against the baselines in `skill/eval/results/`"* — has no left-hand side. That directory is gitignored (`.gitignore:28`) and `git log --all` over it returns empty: **it has never been tracked**. `CLAUDE.md`'s Validating Prompt Changes step 1 gives the same instruction, so that step is inoperable on any fresh clone and in CI.

The import half of #122 was already closed by `tests/test_eval_imports.py` and the `eval-imports` job. What remained was scoring behavior — and that half cannot be answered backwards. It can only be made answerable forwards.

## What this PR does

Every report gains an `**Environment:**` line above the results:

```
# PDCA Eval Report — 2026-09-08 20:34:06

**Environment:** deepeval: 4.2.2, anthropic: 1.4.0
```

Above the results deliberately — it is what tells a reader whether the scores below are comparable to the ones they are being compared against.

`importlib.metadata.version` reads distribution metadata off disk rather than importing, so the reporter stays importable in the default unit suite, which installs neither package. Absence records as `not installed` rather than being omitted: a missing line reads as an older report format, an explicit one records that the package genuinely was absent.

## Called shot

`TestReportProvenance`, five assertions, observed failing first:

```
AssertionError: assert 'deepeval' in '# PDCA Eval Report — 2026-09-08 20:34:06\n\n## Summary\n\n| Scenario | Phase | Score | Threshold | GEval | Mechanical |\n|---...'
```

## A second gap, self-inflicted

With those green, `test_recorded_deepeval_version_matches_the_installed_one` would only ever have exercised the **not-installed** branch — the default suite has no eval extra, and CI's `eval-imports` job runs `test_eval_imports.py` alone. The path producing the version string a human actually reads would have executed **nowhere**. That is the shape of the pre-commit hook in #142: a gate that looks like coverage and provides none.

So `tests/test_evals_reporter.py` now also runs in that job (no API calls, no secret), and `test_ci_exercises_the_reporter_against_installed_eval_dependencies` asserts the job keeps running it.

Its assertion uses `assertTrue` rather than `assertIn`, per the precedent set in #143 — `assertIn` rendered the entire workflow file into the failure message and buried the one line that mattered.

## Verification

```
204 passed, 189 subtests passed
Success: no issues found in 28 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (5 path(s) changed).
```

The changelog guard was run **after committing**. Run against an uncommitted tree it reported `0 path(s) changed` — a number that isn't a measurement, which is the defect #139 was closed over.

## Scope note

Two planned steps moved to the follow-up PR rather than landing here:

- **Repointing `CLAUDE.md` to `skill/eval/baselines/`** — pointing the docs at a directory that does not exist yet would recreate the exact defect being fixed.
- **`test_baseline_exists_for_every_scenario`** — it belongs with the baseline that turns it green, rather than sitting red on `main` between two merges.

The follow-up PR is blocked on #136: freezing `2-superpowers-tdd-precedence` (mean 0.6, stddev 0.36) into the repo's first baseline would make every future comparison against it meaningless. A 10-shot diagnostic is running now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_