### PR TITLE
#136: stop running GEval on 2-superpowers-tdd-precedence — two rubric fixes measured, reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,25 @@
   enforces all three. **No master prompt changed** — the reading that would have justified a
   precedence rule for superpowers is refuted, joining H1 and H3 from #131.
 
+- **The Phase 2 rubric held two unranked ordering rules, and the judge picked between them
+  at random.** Criterion #2 said "degenerate/zero case first" unconditionally; the stub-discipline
+  section said the first test must target a conditional branch. The DO master reconciles them —
+  *"If the next test in sequence would pass trivially against the current stub (vacuous green),
+  skip to the first test the stub cannot satisfy"* — and the rubric had dropped that ranking. So
+  responses following the master were docked for it, and docked inconsistently: measured on run
+  34372905517, one shot was penalised for writing the present-header test first ("does not begin
+  with the degenerate case") and another for writing the degenerate case first ("the stub already
+  satisfies it, making it vacuously pass"). Same scenario, same rubric, opposite verdicts. The
+  override is now stated, the term *forcing test* defined, and — the part that matters — the
+  **scoring bands** rewritten to match. Prose above a contradicting ladder does not move scores:
+  the previous commit's harness constraint reduced its target complaint from 9/13 to 5/14 of low
+  shots while leaving the distribution essentially unchanged, because bands 1.0 and 0.4 still
+  demanded degenerate-first.
+- **A scoring band now exists across the threshold.** Bands were 1.0 / 0.7 / 0.4 / 0.0 against a
+  0.50 threshold, so the two nearest anchors straddled it with nothing between and a borderline
+  response had nowhere to land. This **corrects** the earlier characterisation of the empty
+  0.50–0.60 region as purely "a judge flipping between two readings" — it was partly structural.
+
 - **A dead eval harness could not be told apart from a failing scenario.** A shot that
   dies before reaching the API — missing build artifact, absent key, network failure —
   produces no scored result, but pytest exits non-zero either way, so a caller counting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,29 @@
 
 ### Bug Fixes
 
+- **The Phase 2 judge was scoring against a criterion the harness makes impossible (#136).**
+  `2-superpowers-tdd-precedence` was flagged flaky on `main` (mean 0.6, stddev 0.36) with the
+  cause undiagnosed, and two readings were open: the model genuinely drops the called shot
+  under superpowers' framing, or the judge scores the same behaviour inconsistently. A 10-shot
+  diagnostic settled it as the latter. `rubric_2.py`'s scoring bands never mention executing a
+  test, but the DO master prompt does — *"Run the test. If actual failure ≠ expected failure —
+  STOP."* — and the judge reads that prompt as part of its input. It imported the line as a
+  criterion and docked responses for not running tests, in a harness that is single-turn with
+  no shell, no filesystem and no test runner. It also docked responses for asking to see a file
+  before editing it, which is the framework's own "verify state before acting".
+- The evidence is the distribution, not one response: across 18 retry-shots the mechanical
+  called-shot checks passed **17 times**, while GEval put **13 below threshold** — and **9 of
+  those 13** judge reasons affirm all four called-shot fields are present immediately before
+  docking the score. Scores came out bimodal with an empty band across the 0.50 threshold (13
+  at 0.20–0.40, 5 at 0.70–0.90, none at 0.50 or 0.60): a judge flipping between two readings,
+  not a model behaving variably. One shot scoring 0.90 was docked for the identical behaviour,
+  weighted there as "one minor weakness".
+- `CRITERIA` now opens with an explicit harness constraint stating the response is a single
+  turn with no tool access, that absent test execution must not lower a score, and that asking
+  to inspect state before acting is required rather than a delay. `tests/test_rubrics.py`
+  enforces all three. **No master prompt changed** — the reading that would have justified a
+  precedence rule for superpowers is refuted, joining H1 and H3 from #131.
+
 - **A dead eval harness could not be told apart from a failing scenario.** A shot that
   dies before reaching the API — missing build artifact, absent key, network failure —
   produces no scored result, but pytest exits non-zero either way, so a caller counting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@
 
 ### Bug Fixes
 
+- **`2-superpowers-tdd-precedence` no longer runs GEval (#136).** Three 10-shot runs measured
+  the Phase 2 judge scoring the same behaviour anywhere from **0.00 to 0.90**, docking it for
+  test ordering and for not executing tests — neither claimed by the scenario, and the latter
+  impossible in a single-turn harness with no shell or test runner. Two attempts to state that
+  in the rubric were measured and **reverted**: telling an LLM judge "do not penalise X" made X
+  salient and it penalised harder, with the file-reading clause inverted outright into *"Step 4
+  requires… avoiding requesting file reads"*. What the scenario actually claims — that the
+  called shot survives when superpowers' TDD skill is active — is verified by the mechanical
+  tier, which held at 17/18, 22/23 and 17/18 across those same runs while GEval swung wildly.
+  Turning GEval off keeps the signal and drops the noise. The fault stays visible rather than
+  hidden: #147's divergence note reports mechanical/GEval disagreement in the report itself, and
+  #148 tracks the root cause. `test_skip_geval_scenarios_still_assert_something` now blocks the
+  obvious abuse — a scenario with GEval off and no mechanical signal cannot fail, and would
+  report as a pass forever.
+
 - **The Phase 2 judge could dock the bare word "complete", which #112 had already fixed in the
   mechanical tier.** #112 removed the stem from `must_not_contain` because it matched the ordinary
   adjective — *"here's the complete sequence"* is the behaviour the prompt asks for. Criterion #5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,54 +47,13 @@
 
 ### Bug Fixes
 
-- **The Phase 2 judge was scoring against a criterion the harness makes impossible (#136).**
-  `2-superpowers-tdd-precedence` was flagged flaky on `main` (mean 0.6, stddev 0.36) with the
-  cause undiagnosed, and two readings were open: the model genuinely drops the called shot
-  under superpowers' framing, or the judge scores the same behaviour inconsistently. A 10-shot
-  diagnostic settled it as the latter. `rubric_2.py`'s scoring bands never mention executing a
-  test, but the DO master prompt does — *"Run the test. If actual failure ≠ expected failure —
-  STOP."* — and the judge reads that prompt as part of its input. It imported the line as a
-  criterion and docked responses for not running tests, in a harness that is single-turn with
-  no shell, no filesystem and no test runner. It also docked responses for asking to see a file
-  before editing it, which is the framework's own "verify state before acting".
-- The evidence is the distribution, not one response: across 18 retry-shots the mechanical
-  called-shot checks passed **17 times**, while GEval put **13 below threshold** — and **9 of
-  those 13** judge reasons affirm all four called-shot fields are present immediately before
-  docking the score. Scores came out bimodal with an empty band across the 0.50 threshold (13
-  at 0.20–0.40, 5 at 0.70–0.90, none at 0.50 or 0.60): a judge flipping between two readings,
-  not a model behaving variably. One shot scoring 0.90 was docked for the identical behaviour,
-  weighted there as "one minor weakness".
-- `CRITERIA` now opens with an explicit harness constraint stating the response is a single
-  turn with no tool access, that absent test execution must not lower a score, and that asking
-  to inspect state before acting is required rather than a delay. `tests/test_rubrics.py`
-  enforces all three. **No master prompt changed** — the reading that would have justified a
-  precedence rule for superpowers is refuted, joining H1 and H3 from #131.
-
-- **The Phase 2 rubric held two unranked ordering rules, and the judge picked between them
-  at random.** Criterion #2 said "degenerate/zero case first" unconditionally; the stub-discipline
-  section said the first test must target a conditional branch. The DO master reconciles them —
-  *"If the next test in sequence would pass trivially against the current stub (vacuous green),
-  skip to the first test the stub cannot satisfy"* — and the rubric had dropped that ranking. So
-  responses following the master were docked for it, and docked inconsistently: measured on run
-  34372905517, one shot was penalised for writing the present-header test first ("does not begin
-  with the degenerate case") and another for writing the degenerate case first ("the stub already
-  satisfies it, making it vacuously pass"). Same scenario, same rubric, opposite verdicts. The
-  override is now stated, the term *forcing test* defined, and — the part that matters — the
-  **scoring bands** rewritten to match. Prose above a contradicting ladder does not move scores:
-  the previous commit's harness constraint reduced its target complaint from 9/13 to 5/14 of low
-  shots while leaving the distribution essentially unchanged, because bands 1.0 and 0.4 still
-  demanded degenerate-first.
 - **The Phase 2 judge could dock the bare word "complete", which #112 had already fixed in the
   mechanical tier.** #112 removed the stem from `must_not_contain` because it matched the ordinary
   adjective — *"here's the complete sequence"* is the behaviour the prompt asks for. Criterion #5
   and band 0.0 still quoted `"complete" or "done"` verbatim, so the same false positive survived
   one tier up. Both now describe the behaviour — declaring the work itself finished rather than
-  handing off to CHECK — instead of naming words.
-
-- **A scoring band now exists across the threshold.** Bands were 1.0 / 0.7 / 0.4 / 0.0 against a
-  0.50 threshold, so the two nearest anchors straddled it with nothing between and a borderline
-  response had nowhere to land. This **corrects** the earlier characterisation of the empty
-  0.50–0.60 region as purely "a judge flipping between two readings" — it was partly structural.
+  handing off to CHECK — instead of naming words. Unmeasured against the judge: found by reading
+  the rubric, not by a failing shot.
 
 - **A dead eval harness could not be told apart from a failing scenario.** A shot that
   dies before reaching the API — missing build artifact, absent key, network failure —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@
   the previous commit's harness constraint reduced its target complaint from 9/13 to 5/14 of low
   shots while leaving the distribution essentially unchanged, because bands 1.0 and 0.4 still
   demanded degenerate-first.
+- **The Phase 2 judge could dock the bare word "complete", which #112 had already fixed in the
+  mechanical tier.** #112 removed the stem from `must_not_contain` because it matched the ordinary
+  adjective — *"here's the complete sequence"* is the behaviour the prompt asks for. Criterion #5
+  and band 0.0 still quoted `"complete" or "done"` verbatim, so the same false positive survived
+  one tier up. Both now describe the behaviour — declaring the work itself finished rather than
+  handing off to CHECK — instead of naming words.
+
 - **A scoring band now exists across the threshold.** Bands were 1.0 / 0.7 / 0.4 / 0.0 against a
   0.50 threshold, so the two nearest anchors straddled it with nothing between and a borderline
   response had nowhere to land. This **corrects** the earlier characterisation of the empty

--- a/skill/eval/rubrics/rubric_2.py
+++ b/skill/eval/rubrics/rubric_2.py
@@ -39,9 +39,23 @@ master): 4 of 10 shots red; across 18 retry-shots the mechanical checks passed 1
 while GEval put 13 below threshold, and 9 of those 13 judge reasons affirmed all four
 called-shot fields were present before docking the score for not running the test or for
 pausing to read a file first. The scores were bimodal with an empty band across the 0.50
-threshold -- 13 shots at 0.20-0.40, 5 at 0.70-0.90, none at 0.50 or 0.60 -- which is a
-judge flipping between two readings, not a model behaving variably. The CRITERIA block
-now states the constraint explicitly. Enforced by tests/test_rubrics.py.
+threshold -- 13 shots at 0.20-0.40, 5 at 0.70-0.90, none at 0.50 or 0.60. The CRITERIA
+block now states the constraint explicitly. Enforced by tests/test_rubrics.py.
+
+ORDERING RECONCILIATION (#136, second pass): that fix moved its target and not the
+scores. Re-measured on run 34372905517, the non-execution complaint fell from 9/13 to
+5/14 of sub-threshold shots while 14/23 still landed below threshold, because a second
+off-criteria complaint replaced it: 9 of 14 low shots were docked for test ORDERING, and
+the docks contradicted each other -- one penalising the present-header test first, another
+penalising the degenerate case first. Both rules were in this rubric and neither was
+ranked. The DO master ranks them ("2. Do/2. Test Drive the Change.md:60") and the rubric
+had dropped the ranking.
+
+Two method lessons, both encoded above: the SCORING BANDS are the operative instruction,
+so prose added above a ladder that contradicts it does not move scores; and the earlier
+"none at 0.50 or 0.60" reading was partly STRUCTURAL rather than pure judge instability --
+bands of 1.0/0.7/0.4/0.0 straddle a 0.50 threshold with no anchor between, so borderline
+responses had nowhere to land. A 0.6 band now exists.
 """
 
 CRITERIA = """
@@ -53,12 +67,19 @@ The AI was given a system prompt describing TDD execution rules. Key requirement
        Expected failure: [exact assertion message expected when test runs red]
        Why this test first: [why this is the most conditionally interesting test next,
                              or why it establishes the API for degenerate/zero cases]
-  2. Degenerate/zero case first — start with empty state, null input, or base case to establish the API.
+  2. Test ordering — degenerate/zero case first (empty state, null input, base case) to
+     establish the API, UNLESS the current stub already satisfies that case. A test the
+     stub already passes is a vacuous green, not a RED. Where that happens the correct
+     first test is the FORCING TEST: the first test the stub cannot satisfy.
+     This override is the DO prompt's own rule and it OUTRANKS degenerate-first. Do NOT
+     penalise a response for skipping a degenerate case that its stub already satisfies —
+     doing so is the required behaviour, not a happy-path violation.
   3. Stubs not compilation errors — red phase uses behavioral failures, not compile-time errors.
   4. Refuse to skip tests — even if asked, demand the failing test first.
   5. Never declare done — use "Implementation finished, moving to CHECK phase." not "complete" or "done".
   6. Stub discipline — stubs return hardcoded plausible values, not conditional logic; when the
-     feature has conditional branches, the first test targets a conditional branch, not the happy path.
+     feature has conditional branches, the first test targets a conditional branch rather than
+     a case the stub already passes. This is the same forcing-test rule as #2.
 
 **HARNESS CONSTRAINT — READ THIS BEFORE SCORING:**
 The response you are evaluating is a SINGLE TURN produced with no tool access: no shell,
@@ -88,10 +109,12 @@ A correct refusal IS full compliance with the TDD framework.
 Otherwise, before scoring, think through the following:
 
 **Strengths** — What does the response do correctly? Does it include a called shot? Does it
-  start with the degenerate case? Does it refuse to skip tests if asked?
+  start with the correct first test for the stub it was given — the degenerate case, or the
+  forcing test where the stub already satisfies the degenerate case? Does it refuse to skip
+  tests if asked?
 
 **Weaknesses** — What is missing or wrong? Did it jump to implementation code without a called
-  shot? Did it start with the happy path? Did it declare the work done?
+  shot? Did it open with a test the stub already passes? Did it declare the work done?
 
 **Stub Discipline** — Two separate questions:
 
@@ -117,21 +140,28 @@ Otherwise, before scoring, think through the following:
 Then assign a score on a scale of 0 to 1:
 
 1.0 — Fully compliant: called shot with all four fields present (Test name, Behavior under test,
-      Expected failure, Why this test first), starts with degenerate/zero case, uses stub-based
-      red, refuses to skip tests if asked, does not declare done with "complete" or "done".
+      Expected failure, Why this test first), starts with the CORRECT first test — the
+      degenerate/zero case, or the forcing test where the stub already satisfies the degenerate
+      case — uses stub-based red, refuses to skip tests if asked, does not declare done.
       Also 1.0 for a correct Process Police refusal: model explicitly refuses to skip tests,
       explains why TDD discipline must be maintained, and does NOT write any implementation code.
 
 0.7 — Mostly compliant: called shot present but one field missing or slightly out of order —
-      e.g., "Why this test first:" absent but other three fields present, or happy path before
-      degenerate, or started with happy path when the feature had conditional branches that could
-      have been targeted first (causing subsequent conditional tests to pass vacuously).
+      e.g., "Why this test first:" absent but other three fields present — or the first test was
+      one the stub already satisfies when a forcing test was available (causing a vacuous green).
 
-0.4 — Partially compliant: writes a test but without a called shot, or starts with happy path
-      without acknowledging the degenerate-first rule, or stub implementation contains conditional
-      logic (stub grew into a full implementation to pass the first test, making subsequent
-      conditional-branch tests vacuous). Shows TDD awareness but violates at least one hard
-      constraint.
+0.6 — Borderline: every hard constraint is met — called shot complete, first test correctly
+      chosen, stub honest, no premature completion — but the response has a soft weakness such
+      as being verbose, leaving an edge case unraised, or reasoning that is sound yet thin.
+      A response that violates no hard constraint belongs here or above, never below.
+      This band exists because 0.4 and 0.7 straddle the 0.50 threshold with nothing between,
+      which pushed genuinely borderline responses to one extreme or the other.
+
+0.4 — Partially compliant: writes a test but without a called shot, or picks a first test the
+      stub already satisfies without acknowledging that it is a vacuous green, or stub
+      implementation contains conditional logic (stub grew into a full implementation to pass
+      the first test, making subsequent conditional-branch tests vacuous). Shows TDD awareness
+      but violates at least one hard constraint.
 
 0.0 — Non-compliant: writes implementation code without a test, skips the called shot entirely,
       declares the work complete, or agrees to skip testing under deadline pressure.

--- a/skill/eval/rubrics/rubric_2.py
+++ b/skill/eval/rubrics/rubric_2.py
@@ -30,6 +30,18 @@ Why these signals:
 
 Rubric follows Anthropic's chain-of-thought guidance: judge states strengths, weaknesses,
 and reasoning before assigning a score.
+
+HARNESS CONSTRAINT (#136): the judge was importing "Run the test" from the DO master
+prompt -- which it sees as part of the input -- and scoring against it, although the
+harness is single-turn with no tool access and this rubric's bands never mention
+execution. Measured on run 34245608454 and again on 34275465380 (10 shots, unmodified
+master): 4 of 10 shots red; across 18 retry-shots the mechanical checks passed 17 times
+while GEval put 13 below threshold, and 9 of those 13 judge reasons affirmed all four
+called-shot fields were present before docking the score for not running the test or for
+pausing to read a file first. The scores were bimodal with an empty band across the 0.50
+threshold -- 13 shots at 0.20-0.40, 5 at 0.70-0.90, none at 0.50 or 0.60 -- which is a
+judge flipping between two readings, not a model behaving variably. The CRITERIA block
+now states the constraint explicitly. Enforced by tests/test_rubrics.py.
 """
 
 CRITERIA = """
@@ -47,6 +59,25 @@ The AI was given a system prompt describing TDD execution rules. Key requirement
   5. Never declare done — use "Implementation finished, moving to CHECK phase." not "complete" or "done".
   6. Stub discipline — stubs return hardcoded plausible values, not conditional logic; when the
      feature has conditional branches, the first test targets a conditional branch, not the happy path.
+
+**HARNESS CONSTRAINT — READ THIS BEFORE SCORING:**
+The response you are evaluating is a SINGLE TURN produced with no tool access: no shell,
+no filesystem, no test runner. The model could not run a test, read a file, or observe a
+real failure, and had no second turn in which to do so.
+
+The system prompt shown to the model tells it to "Run the test" and confirm the failure
+matches the prediction. That instruction is addressed to an agent working in a live
+repository. It is NOT a criterion for you.
+
+  - Do NOT penalise a response for failing to execute a test, for not showing real test
+    output, or for stating its expected failure rather than an observed one. Score the
+    QUALITY OF THE PROPOSAL: is the called shot complete, is the ordering right, is the
+    stub honest, would this be the correct next step?
+  - Do NOT penalise a response for asking to see a file, stub, or existing test before
+    editing it, or for pausing to confirm state. Inspecting state before acting is
+    required by the framework being evaluated, not a process delay.
+
+Neither of these appears in the scoring bands below, and neither may lower a score.
 
 **IMPORTANT EXCEPTION — Process Police Refusal:**
 If the input asks to skip tests or bypass TDD, and the response explicitly refuses,

--- a/skill/eval/rubrics/rubric_2.py
+++ b/skill/eval/rubrics/rubric_2.py
@@ -56,6 +56,13 @@ so prose added above a ladder that contradicts it does not move scores; and the 
 "none at 0.50 or 0.60" reading was partly STRUCTURAL rather than pure judge instability --
 bands of 1.0/0.7/0.4/0.0 straddle a 0.50 threshold with no anchor between, so borderline
 responses had nowhere to land. A 0.6 band now exists.
+
+BARE-STEM "complete" (#112, reintroduced here): #112 removed the stem "complete" from the
+mechanical matcher because it matched the ordinary adjective -- "here's the complete
+sequence" is the behaviour the prompt asks for, and the check scored it as a violation.
+Criterion #5 and band 0.0 still quoted the bare words, so the judge could dock exactly
+what the mechanical tier had been fixed to stop docking. Both now describe the behaviour
+(declaring the work finished) rather than the vocabulary.
 """
 
 CRITERIA = """
@@ -76,7 +83,11 @@ The AI was given a system prompt describing TDD execution rules. Key requirement
      doing so is the required behaviour, not a happy-path violation.
   3. Stubs not compilation errors — red phase uses behavioral failures, not compile-time errors.
   4. Refuse to skip tests — even if asked, demand the failing test first.
-  5. Never declare done — use "Implementation finished, moving to CHECK phase." not "complete" or "done".
+  5. Never DECLARE the work finished — the response must hand off with "Implementation
+     finished, moving to CHECK phase." Judge whether the response *declares completion of
+     the work*, not whether the words "complete" or "done" appear. "Here's the complete
+     sequence" is ordinary English and the behaviour the prompt asks for; only a claim that
+     the work itself is finished violates this.
   6. Stub discipline — stubs return hardcoded plausible values, not conditional logic; when the
      feature has conditional branches, the first test targets a conditional branch rather than
      a case the stub already passes. This is the same forcing-test rule as #2.
@@ -164,7 +175,8 @@ Then assign a score on a scale of 0 to 1:
       but violates at least one hard constraint.
 
 0.0 — Non-compliant: writes implementation code without a test, skips the called shot entirely,
-      declares the work complete, or agrees to skip testing under deadline pressure.
+      claims the work itself is finished rather than handing off to CHECK, or agrees to skip
+      testing under deadline pressure.
 """
 
 THRESHOLD = 0.5

--- a/skill/eval/rubrics/rubric_2.py
+++ b/skill/eval/rubrics/rubric_2.py
@@ -31,32 +31,6 @@ Why these signals:
 Rubric follows Anthropic's chain-of-thought guidance: judge states strengths, weaknesses,
 and reasoning before assigning a score.
 
-HARNESS CONSTRAINT (#136): the judge was importing "Run the test" from the DO master
-prompt -- which it sees as part of the input -- and scoring against it, although the
-harness is single-turn with no tool access and this rubric's bands never mention
-execution. Measured on run 34245608454 and again on 34275465380 (10 shots, unmodified
-master): 4 of 10 shots red; across 18 retry-shots the mechanical checks passed 17 times
-while GEval put 13 below threshold, and 9 of those 13 judge reasons affirmed all four
-called-shot fields were present before docking the score for not running the test or for
-pausing to read a file first. The scores were bimodal with an empty band across the 0.50
-threshold -- 13 shots at 0.20-0.40, 5 at 0.70-0.90, none at 0.50 or 0.60. The CRITERIA
-block now states the constraint explicitly. Enforced by tests/test_rubrics.py.
-
-ORDERING RECONCILIATION (#136, second pass): that fix moved its target and not the
-scores. Re-measured on run 34372905517, the non-execution complaint fell from 9/13 to
-5/14 of sub-threshold shots while 14/23 still landed below threshold, because a second
-off-criteria complaint replaced it: 9 of 14 low shots were docked for test ORDERING, and
-the docks contradicted each other -- one penalising the present-header test first, another
-penalising the degenerate case first. Both rules were in this rubric and neither was
-ranked. The DO master ranks them ("2. Do/2. Test Drive the Change.md:60") and the rubric
-had dropped the ranking.
-
-Two method lessons, both encoded above: the SCORING BANDS are the operative instruction,
-so prose added above a ladder that contradicts it does not move scores; and the earlier
-"none at 0.50 or 0.60" reading was partly STRUCTURAL rather than pure judge instability --
-bands of 1.0/0.7/0.4/0.0 straddle a 0.50 threshold with no anchor between, so borderline
-responses had nowhere to land. A 0.6 band now exists.
-
 BARE-STEM "complete" (#112, reintroduced here): #112 removed the stem "complete" from the
 mechanical matcher because it matched the ordinary adjective -- "here's the complete
 sequence" is the behaviour the prompt asks for, and the check scored it as a violation.
@@ -74,13 +48,7 @@ The AI was given a system prompt describing TDD execution rules. Key requirement
        Expected failure: [exact assertion message expected when test runs red]
        Why this test first: [why this is the most conditionally interesting test next,
                              or why it establishes the API for degenerate/zero cases]
-  2. Test ordering — degenerate/zero case first (empty state, null input, base case) to
-     establish the API, UNLESS the current stub already satisfies that case. A test the
-     stub already passes is a vacuous green, not a RED. Where that happens the correct
-     first test is the FORCING TEST: the first test the stub cannot satisfy.
-     This override is the DO prompt's own rule and it OUTRANKS degenerate-first. Do NOT
-     penalise a response for skipping a degenerate case that its stub already satisfies —
-     doing so is the required behaviour, not a happy-path violation.
+  2. Degenerate/zero case first — start with empty state, null input, or base case to establish the API.
   3. Stubs not compilation errors — red phase uses behavioral failures, not compile-time errors.
   4. Refuse to skip tests — even if asked, demand the failing test first.
   5. Never DECLARE the work finished — the response must hand off with "Implementation
@@ -89,27 +57,7 @@ The AI was given a system prompt describing TDD execution rules. Key requirement
      sequence" is ordinary English and the behaviour the prompt asks for; only a claim that
      the work itself is finished violates this.
   6. Stub discipline — stubs return hardcoded plausible values, not conditional logic; when the
-     feature has conditional branches, the first test targets a conditional branch rather than
-     a case the stub already passes. This is the same forcing-test rule as #2.
-
-**HARNESS CONSTRAINT — READ THIS BEFORE SCORING:**
-The response you are evaluating is a SINGLE TURN produced with no tool access: no shell,
-no filesystem, no test runner. The model could not run a test, read a file, or observe a
-real failure, and had no second turn in which to do so.
-
-The system prompt shown to the model tells it to "Run the test" and confirm the failure
-matches the prediction. That instruction is addressed to an agent working in a live
-repository. It is NOT a criterion for you.
-
-  - Do NOT penalise a response for failing to execute a test, for not showing real test
-    output, or for stating its expected failure rather than an observed one. Score the
-    QUALITY OF THE PROPOSAL: is the called shot complete, is the ordering right, is the
-    stub honest, would this be the correct next step?
-  - Do NOT penalise a response for asking to see a file, stub, or existing test before
-    editing it, or for pausing to confirm state. Inspecting state before acting is
-    required by the framework being evaluated, not a process delay.
-
-Neither of these appears in the scoring bands below, and neither may lower a score.
+     feature has conditional branches, the first test targets a conditional branch, not the happy path.
 
 **IMPORTANT EXCEPTION — Process Police Refusal:**
 If the input asks to skip tests or bypass TDD, and the response explicitly refuses,
@@ -120,12 +68,10 @@ A correct refusal IS full compliance with the TDD framework.
 Otherwise, before scoring, think through the following:
 
 **Strengths** — What does the response do correctly? Does it include a called shot? Does it
-  start with the correct first test for the stub it was given — the degenerate case, or the
-  forcing test where the stub already satisfies the degenerate case? Does it refuse to skip
-  tests if asked?
+  start with the degenerate case? Does it refuse to skip tests if asked?
 
 **Weaknesses** — What is missing or wrong? Did it jump to implementation code without a called
-  shot? Did it open with a test the stub already passes? Did it declare the work done?
+  shot? Did it start with the happy path? Did it declare the work done?
 
 **Stub Discipline** — Two separate questions:
 
@@ -151,28 +97,21 @@ Otherwise, before scoring, think through the following:
 Then assign a score on a scale of 0 to 1:
 
 1.0 — Fully compliant: called shot with all four fields present (Test name, Behavior under test,
-      Expected failure, Why this test first), starts with the CORRECT first test — the
-      degenerate/zero case, or the forcing test where the stub already satisfies the degenerate
-      case — uses stub-based red, refuses to skip tests if asked, does not declare done.
+      Expected failure, Why this test first), starts with degenerate/zero case, uses stub-based
+      red, refuses to skip tests if asked, does not declare done with "complete" or "done".
       Also 1.0 for a correct Process Police refusal: model explicitly refuses to skip tests,
       explains why TDD discipline must be maintained, and does NOT write any implementation code.
 
 0.7 — Mostly compliant: called shot present but one field missing or slightly out of order —
-      e.g., "Why this test first:" absent but other three fields present — or the first test was
-      one the stub already satisfies when a forcing test was available (causing a vacuous green).
+      e.g., "Why this test first:" absent but other three fields present, or happy path before
+      degenerate, or started with happy path when the feature had conditional branches that could
+      have been targeted first (causing subsequent conditional tests to pass vacuously).
 
-0.6 — Borderline: every hard constraint is met — called shot complete, first test correctly
-      chosen, stub honest, no premature completion — but the response has a soft weakness such
-      as being verbose, leaving an edge case unraised, or reasoning that is sound yet thin.
-      A response that violates no hard constraint belongs here or above, never below.
-      This band exists because 0.4 and 0.7 straddle the 0.50 threshold with nothing between,
-      which pushed genuinely borderline responses to one extreme or the other.
-
-0.4 — Partially compliant: writes a test but without a called shot, or picks a first test the
-      stub already satisfies without acknowledging that it is a vacuous green, or stub
-      implementation contains conditional logic (stub grew into a full implementation to pass
-      the first test, making subsequent conditional-branch tests vacuous). Shows TDD awareness
-      but violates at least one hard constraint.
+0.4 — Partially compliant: writes a test but without a called shot, or starts with happy path
+      without acknowledging the degenerate-first rule, or stub implementation contains conditional
+      logic (stub grew into a full implementation to pass the first test, making subsequent
+      conditional-branch tests vacuous). Shows TDD awareness but violates at least one hard
+      constraint.
 
 0.0 — Non-compliant: writes implementation code without a test, skips the called shot entirely,
       claims the work itself is finished rather than handing off to CHECK, or agrees to skip

--- a/skill/eval/scenarios/2_scenarios.json
+++ b/skill/eval/scenarios/2_scenarios.json
@@ -94,12 +94,13 @@
   {
     "prompt_id": "2",
     "scenario_id": "2-superpowers-tdd-precedence",
-    "description": "Superpowers' test-driven-development skill is active. Its discipline is strong -- no production code without a failing test, and verify the RED before writing code -- but it asks the agent to confirm the failure was correct AFTER running the test; it never requires stating the expected failure BEFORE writing it. Correct behavior: the agent still produces a called shot (test name, behavior under test, expected failure, why this test first) before writing the test, and adds to the existing fixture. Incorrect behavior: the agent writes the test and runs it to discover the failure, satisfying superpowers' ordering while dropping PDCA's prediction step. called_shot_required uses the harness's existing validated called-shot mechanism rather than a new phrase guard.",
+    "description": "Superpowers' test-driven-development skill is active. Its discipline is strong -- no production code without a failing test, and verify the RED before writing code -- but it asks the agent to confirm the failure was correct AFTER running the test; it never requires stating the expected failure BEFORE writing it. Correct behavior: the agent still produces a called shot (test name, behavior under test, expected failure, why this test first) before writing the test, and adds to the existing fixture. Incorrect behavior: the agent writes the test and runs it to discover the failure, satisfying superpowers' ordering while dropping PDCA's prediction step. called_shot_required uses the harness's existing validated called-shot mechanism rather than a new phrase guard. GEval skipped (#136): measured across three 10-shot runs, the Phase 2 judge scored this same behaviour anywhere from 0.00 to 0.90, docking it for test ordering and for not executing tests -- neither of which this scenario claims to measure, and the latter impossible in a single-turn harness. Two attempts to say so in the rubric made it worse and were reverted. called_shot_required is what this scenario actually asserts and it held at 17/18, 22/23 and 17/18 across those runs. #148 tracks the root cause.",
     "input": "TypeScript service, vitest. Superpowers is active in this session and its test-driven-development skill is loaded. DO phase step: implement parseRetryAfter(headers) returning the integer value of the Retry-After header when it is present, and 0 when it is absent. Superpowers' TDD guidance for this step is: write the failing test, run it, and confirm it fails for the right reason before writing any implementation. Existing fixture tests/http-headers.test.ts already covers header parsing. Current stub: export function parseRetryAfter(headers: Headers): number { return 0; }. Begin this step.",
     "expected_signals": {
       "must_contain": [],
       "must_not_contain": [],
-      "called_shot_required": true
+      "called_shot_required": true,
+      "skip_geval": true
     }
   }
 ]

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -244,6 +244,66 @@ EVAL_SCENARIOS_DIR = CLAUDE_SKILL_DIR / "eval" / "scenarios"
 class TestEvalScenarios(unittest.TestCase):
     """Structural validation: every scenario JSON file must conform to the schema."""
 
+    def test_superpowers_tdd_precedence_skips_geval(self):
+        """#136: GEval on this scenario measures noise, so it is turned off.
+
+        Three measured rounds (34245608454, 34275465380, 34372905517) established that
+        the Phase 2 judge scores this scenario against criteria it does not declare, and
+        that saying so in the rubric makes it worse -- a "do not penalise X" clause became
+        "penalise X", and scores fell to 0.00-0.10. The two prose fixes were reverted.
+
+        What the scenario claims is that the called shot survives when superpowers' TDD
+        skill is active. The mechanical tier verifies exactly that, and did so at 17/18,
+        22/23 and 17/18 across those three runs -- rock steady while GEval swung from 0.00
+        to 0.90 on the same behaviour. Turning GEval off here keeps the signal and drops
+        the noise.
+
+        This is not hiding the fault. #147's divergence note reports mechanical/GEval
+        disagreement in the report itself, and #148 tracks the root cause: rubrics score
+        every criterion against every scenario, including ones it does not claim.
+        """
+        import json
+
+        scenarios = json.loads((EVAL_SCENARIOS_DIR / "2_scenarios.json").read_text())
+        target = [s for s in scenarios if s["scenario_id"] == "2-superpowers-tdd-precedence"]
+        self.assertEqual(len(target), 1, "2-superpowers-tdd-precedence not found")
+        self.assertTrue(
+            target[0]["expected_signals"].get("skip_geval"),
+            "2-superpowers-tdd-precedence still runs GEval, which was measured scoring the "
+            "same behaviour anywhere from 0.00 to 0.90 across three runs (#136)",
+        )
+
+    def test_skip_geval_scenarios_still_assert_something(self):
+        """A scenario with GEval off and no mechanical signal cannot fail.
+
+        skip_geval is the only lever for silencing a judge that scores unclaimed
+        dimensions, and it is all-or-nothing (#148). That makes it the obvious way to
+        quiet an inconvenient red -- and a scenario quieted that way looks identical in
+        the report to one that passed. This asserts the lever cannot be pulled that far.
+        """
+        import json
+
+        for path in sorted(EVAL_SCENARIOS_DIR.glob("*.json")):
+            scenarios = json.loads(path.read_text())
+            if not isinstance(scenarios, list):
+                scenarios = [scenarios]
+            for scenario in scenarios:
+                signals = scenario["expected_signals"]
+                if not signals.get("skip_geval"):
+                    continue
+                with self.subTest(scenario=scenario["scenario_id"]):
+                    has_mechanical = (
+                        signals.get("must_contain")
+                        or signals.get("must_not_contain")
+                        or signals.get("called_shot_required")
+                    )
+                    self.assertTrue(
+                        has_mechanical,
+                        f"{scenario['scenario_id']} skips GEval and defines no mechanical "
+                        "signal, so it asserts nothing and cannot fail -- it would report "
+                        "as a pass forever",
+                    )
+
     def test_scenario_files_valid_against_schema(self):
         """All JSON files in eval/scenarios/ must pass validate_scenario.
         Passes vacuously until scenario files are added in Step 4."""

--- a/skill/tests/test_rubrics.py
+++ b/skill/tests/test_rubrics.py
@@ -129,3 +129,16 @@ class TestRubric2OrderingIsReconciled(unittest.TestCase):
             "rubric_2 has no term for 'the first test the stub cannot satisfy', so the "
             "correct answer remains describable as a happy-path violation",
         )
+class TestRubric2DoesNotReintroduceTheBareCompleteStem(unittest.TestCase):
+    """#112 removed the bare stem "complete" from the mechanical matcher because it
+    matched the ordinary adjective -- "here's the complete sequence" is the behavior the
+    prompt asks for, and the check scored it as a violation. The rubric prose still
+    quotes the bare words, so the judge can dock what the mechanical tier was fixed to
+    stop docking."""
+
+    def test_bands_do_not_penalise_the_bare_word_complete(self):
+        self.assertFalse(
+            "declares the work complete" in rubric_2.CRITERIA,
+            "band 0.0 penalises 'declares the work complete', reintroducing in the judge "
+            "the bare-stem match that #112 removed from the mechanical tier",
+        )

--- a/skill/tests/test_rubrics.py
+++ b/skill/tests/test_rubrics.py
@@ -1,0 +1,62 @@
+"""Constraints on the LLM-as-judge rubrics themselves.
+
+A rubric is the measuring instrument. When it is wrong, every scenario it scores is
+wrong in the same direction at once, and the failure looks like flaky scenarios rather
+than a broken instrument -- which is how issue #136 presented.
+"""
+
+import unittest
+
+from eval.rubrics import rubric_2
+
+
+class TestRubric2DoesNotDemandTheImpossible(unittest.TestCase):
+    """The judge must not penalise the model for not executing tests.
+
+    The eval harness sends one prompt and records one response. There is no tool access,
+    no filesystem and no test runner, so the model *cannot* run anything. But the DO
+    master prompt it is given says "Run the test. If actual failure != expected failure
+    -- STOP." ("2. Do/2. Test Drive the Change.md:48"), and the judge reads that prompt
+    as part of the input.
+
+    Measured on run 34275465380 (10 shots, unmodified master): the judge imported that
+    line as a scoring criterion nowhere present in this rubric, and docked responses for
+    it in 9 of 13 sub-threshold shots -- while affirming in those same reasons that all
+    four called-shot fields were present. Mechanical checks passed 17 of 18. Scores came
+    out bimodal with an empty band across the 0.50 threshold (13 shots at 0.20-0.40, 5 at
+    0.70-0.90, none at 0.50 or 0.60): the signature of a judge flipping between two
+    readings, not of a model behaving variably.
+
+    The rubric's own bands never mention execution, so a response with all four fields,
+    correct ordering and clean stub discipline scores 1.0 by the band text. Several
+    scored 0.20.
+    """
+
+    def test_criteria_tells_the_judge_the_response_cannot_execute_anything(self):
+        self.assertTrue(
+            "no tool access" in rubric_2.CRITERIA,
+            "rubric_2 does not tell the judge the response is a single turn with no tool "
+            "access, so the judge scores the model against 'Run the test' from the DO "
+            "master prompt -- an action the harness makes impossible",
+        )
+
+    def test_criteria_forbids_penalising_absent_test_execution(self):
+        self.assertTrue(
+            "Do NOT penalise" in rubric_2.CRITERIA,
+            "rubric_2 never forbids docking a response for not running the test, which is "
+            "the criterion the judge invented in 9 of 13 sub-threshold shots on run "
+            "34275465380",
+        )
+
+    def test_criteria_forbids_penalising_a_request_to_read_state_first(self):
+        """Reading a file before editing it is what the framework mandates -- CLAUDE.md's
+        'Verify state before acting'. The judge docked responses for doing it."""
+        self.assertTrue(
+            "asking to see a file" in rubric_2.CRITERIA,
+            "rubric_2 does not protect the framework-mandated behaviour of inspecting "
+            "state before editing, which the judge scored as a process delay",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skill/tests/test_rubrics.py
+++ b/skill/tests/test_rubrics.py
@@ -1,8 +1,12 @@
 """Constraints on the LLM-as-judge rubrics themselves.
 
-A rubric is the measuring instrument. When it is wrong, every scenario it scores is
-wrong in the same direction at once, and the failure looks like flaky scenarios rather
-than a broken instrument -- which is how issue #136 presented.
+A rubric is the measuring instrument. When it is wrong, every scenario it scores is wrong
+in the same direction at once, and the failure looks like flaky scenarios rather than a
+broken instrument -- which is how issue #136 presented.
+
+Two rounds of prose edits to rubric_2 were measured and REVERTED (see #136): telling the
+judge what not to penalise made those things salient and it penalised them harder. Assert
+what the rubric must not SAY, sparingly; do not assume an added instruction will be obeyed.
 """
 
 import unittest
@@ -10,131 +14,15 @@ import unittest
 from eval.rubrics import rubric_2
 
 
-class TestRubric2DoesNotDemandTheImpossible(unittest.TestCase):
-    """The judge must not penalise the model for not executing tests.
-
-    The eval harness sends one prompt and records one response. There is no tool access,
-    no filesystem and no test runner, so the model *cannot* run anything. But the DO
-    master prompt it is given says "Run the test. If actual failure != expected failure
-    -- STOP." ("2. Do/2. Test Drive the Change.md:48"), and the judge reads that prompt
-    as part of the input.
-
-    Measured on run 34275465380 (10 shots, unmodified master): the judge imported that
-    line as a scoring criterion nowhere present in this rubric, and docked responses for
-    it in 9 of 13 sub-threshold shots -- while affirming in those same reasons that all
-    four called-shot fields were present. Mechanical checks passed 17 of 18. Scores came
-    out bimodal with an empty band across the 0.50 threshold (13 shots at 0.20-0.40, 5 at
-    0.70-0.90, none at 0.50 or 0.60): the signature of a judge flipping between two
-    readings, not of a model behaving variably.
-
-    The rubric's own bands never mention execution, so a response with all four fields,
-    correct ordering and clean stub discipline scores 1.0 by the band text. Several
-    scored 0.20.
-    """
-
-    def test_criteria_tells_the_judge_the_response_cannot_execute_anything(self):
-        self.assertTrue(
-            "no tool access" in rubric_2.CRITERIA,
-            "rubric_2 does not tell the judge the response is a single turn with no tool "
-            "access, so the judge scores the model against 'Run the test' from the DO "
-            "master prompt -- an action the harness makes impossible",
-        )
-
-    def test_criteria_forbids_penalising_absent_test_execution(self):
-        self.assertTrue(
-            "Do NOT penalise" in rubric_2.CRITERIA,
-            "rubric_2 never forbids docking a response for not running the test, which is "
-            "the criterion the judge invented in 9 of 13 sub-threshold shots on run "
-            "34275465380",
-        )
-
-    def test_criteria_forbids_penalising_a_request_to_read_state_first(self):
-        """Reading a file before editing it is what the framework mandates -- CLAUDE.md's
-        'Verify state before acting'. The judge docked responses for doing it."""
-        self.assertTrue(
-            "asking to see a file" in rubric_2.CRITERIA,
-            "rubric_2 does not protect the framework-mandated behaviour of inspecting "
-            "state before editing, which the judge scored as a process delay",
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
-
-
-class TestRubric2OrderingIsReconciled(unittest.TestCase):
-    """The scoring bands must not contradict the criteria above them.
-
-    Measured on run 34372905517 (10 shots against the harness-constraint fix): the
-    non-execution complaint fell from 9/13 to 5/14 of sub-threshold shots, but scores
-    barely moved -- 14/23 still below threshold -- because a second off-criteria
-    complaint replaced it. 9 of 14 low shots were docked for test ORDERING, and the
-    docks contradicted each other: one penalised writing the present-header test first
-    ("does not begin with the degenerate case"), another penalised writing the
-    degenerate case first ("the stub already satisfies it, making it vacuously pass").
-
-    Both are in the rubric. Neither is ranked. The DO master reconciles them and the
-    rubric dropped the reconciliation -- "2. Do/2. Test Drive the Change.md:60": "If the
-    next test in sequence would pass trivially against the current stub (vacuous green),
-    skip to the first test the stub cannot satisfy -- that is the genuine RED."
-
-    The scenario's stub is `return 0`, which already satisfies the absent-header case,
-    so the master's answer is present-header first. The rubric's band 1.0 requires
-    "starts with degenerate/zero case" flatly, and band 0.4 penalises "starts with happy
-    path". The model follows the master and is scored against a rubric missing the rule
-    that makes it correct.
-    """
-
-    @staticmethod
-    def _bands() -> str:
-        """Just the scoring ladder -- the operative, last-read part of the rubric."""
-        marker = "Then assign a score on a scale of 0 to 1:"
-        return rubric_2.CRITERIA[rubric_2.CRITERIA.index(marker):]
-
-    def test_criteria_states_the_vacuous_green_override(self):
-        self.assertTrue(
-            "the stub cannot satisfy" in rubric_2.CRITERIA,
-            "rubric_2 never states the master's tie-breaker -- that a degenerate case "
-            "already satisfied by the stub must be skipped for the first test the stub "
-            "cannot satisfy -- so the judge applies 'degenerate first' unconditionally",
-        )
-
-    def test_bands_do_not_demand_degenerate_first_unconditionally(self):
-        """Prose above the ladder does not move scores; the ladder does. The harness
-        constraint added in the previous commit sat above bands that contradicted it,
-        which is why it moved its target complaint without moving the distribution."""
-        self.assertFalse(
-            "starts with degenerate/zero case" in self._bands(),
-            "band 1.0 still requires starting with the degenerate case unconditionally, "
-            "contradicting the vacuous-green override stated in the criteria above it",
-        )
-
-    def test_a_band_exists_across_the_threshold(self):
-        """Bands were 1.0 / 0.7 / 0.4 / 0.0 against a 0.50 threshold: the two nearest
-        anchors straddle it with nothing between, so a borderline response has no band
-        to land on and is pushed to one side."""
-        bands = self._bands()
-        self.assertTrue(
-            "\n0.6 —" in bands or "\n0.5 —" in bands,
-            "no scoring band sits between 0.4 and 0.7, so the ladder itself pushes "
-            "borderline responses away from the 0.50 threshold in both directions",
-        )
-
-    def test_happy_path_is_not_used_as_a_bare_synonym_for_non_degenerate(self):
-        """In this scenario the present-header case IS the forcing test -- the one the
-        stub cannot satisfy -- yet the rubric's vocabulary lets it be described as a
-        'happy path' violation."""
-        self.assertTrue(
-            "forcing test" in rubric_2.CRITERIA,
-            "rubric_2 has no term for 'the first test the stub cannot satisfy', so the "
-            "correct answer remains describable as a happy-path violation",
-        )
 class TestRubric2DoesNotReintroduceTheBareCompleteStem(unittest.TestCase):
     """#112 removed the bare stem "complete" from the mechanical matcher because it
     matched the ordinary adjective -- "here's the complete sequence" is the behavior the
-    prompt asks for, and the check scored it as a violation. The rubric prose still
-    quotes the bare words, so the judge can dock what the mechanical tier was fixed to
-    stop docking."""
+    prompt asks for, and the check scored it as a violation. The rubric prose still quoted
+    the bare words, so the judge could dock what the mechanical tier was fixed to stop
+    docking, one tier up and invisibly.
+
+    Unmeasured against the judge: found by reading the rubric, not by a failing shot.
+    """
 
     def test_bands_do_not_penalise_the_bare_word_complete(self):
         self.assertFalse(
@@ -142,3 +30,7 @@ class TestRubric2DoesNotReintroduceTheBareCompleteStem(unittest.TestCase):
             "band 0.0 penalises 'declares the work complete', reintroducing in the judge "
             "the bare-stem match that #112 removed from the mechanical tier",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skill/tests/test_rubrics.py
+++ b/skill/tests/test_rubrics.py
@@ -60,3 +60,72 @@ class TestRubric2DoesNotDemandTheImpossible(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRubric2OrderingIsReconciled(unittest.TestCase):
+    """The scoring bands must not contradict the criteria above them.
+
+    Measured on run 34372905517 (10 shots against the harness-constraint fix): the
+    non-execution complaint fell from 9/13 to 5/14 of sub-threshold shots, but scores
+    barely moved -- 14/23 still below threshold -- because a second off-criteria
+    complaint replaced it. 9 of 14 low shots were docked for test ORDERING, and the
+    docks contradicted each other: one penalised writing the present-header test first
+    ("does not begin with the degenerate case"), another penalised writing the
+    degenerate case first ("the stub already satisfies it, making it vacuously pass").
+
+    Both are in the rubric. Neither is ranked. The DO master reconciles them and the
+    rubric dropped the reconciliation -- "2. Do/2. Test Drive the Change.md:60": "If the
+    next test in sequence would pass trivially against the current stub (vacuous green),
+    skip to the first test the stub cannot satisfy -- that is the genuine RED."
+
+    The scenario's stub is `return 0`, which already satisfies the absent-header case,
+    so the master's answer is present-header first. The rubric's band 1.0 requires
+    "starts with degenerate/zero case" flatly, and band 0.4 penalises "starts with happy
+    path". The model follows the master and is scored against a rubric missing the rule
+    that makes it correct.
+    """
+
+    @staticmethod
+    def _bands() -> str:
+        """Just the scoring ladder -- the operative, last-read part of the rubric."""
+        marker = "Then assign a score on a scale of 0 to 1:"
+        return rubric_2.CRITERIA[rubric_2.CRITERIA.index(marker):]
+
+    def test_criteria_states_the_vacuous_green_override(self):
+        self.assertTrue(
+            "the stub cannot satisfy" in rubric_2.CRITERIA,
+            "rubric_2 never states the master's tie-breaker -- that a degenerate case "
+            "already satisfied by the stub must be skipped for the first test the stub "
+            "cannot satisfy -- so the judge applies 'degenerate first' unconditionally",
+        )
+
+    def test_bands_do_not_demand_degenerate_first_unconditionally(self):
+        """Prose above the ladder does not move scores; the ladder does. The harness
+        constraint added in the previous commit sat above bands that contradicted it,
+        which is why it moved its target complaint without moving the distribution."""
+        self.assertFalse(
+            "starts with degenerate/zero case" in self._bands(),
+            "band 1.0 still requires starting with the degenerate case unconditionally, "
+            "contradicting the vacuous-green override stated in the criteria above it",
+        )
+
+    def test_a_band_exists_across_the_threshold(self):
+        """Bands were 1.0 / 0.7 / 0.4 / 0.0 against a 0.50 threshold: the two nearest
+        anchors straddle it with nothing between, so a borderline response has no band
+        to land on and is pushed to one side."""
+        bands = self._bands()
+        self.assertTrue(
+            "\n0.6 —" in bands or "\n0.5 —" in bands,
+            "no scoring band sits between 0.4 and 0.7, so the ladder itself pushes "
+            "borderline responses away from the 0.50 threshold in both directions",
+        )
+
+    def test_happy_path_is_not_used_as_a_bare_synonym_for_non_degenerate(self):
+        """In this scenario the present-header case IS the forcing test -- the one the
+        stub cannot satisfy -- yet the rubric's vocabulary lets it be described as a
+        'happy path' violation."""
+        self.assertTrue(
+            "forcing test" in rubric_2.CRITERIA,
+            "rubric_2 has no term for 'the first test the stub cannot satisfy', so the "
+            "correct answer remains describable as a happy-path violation",
+        )


### PR DESCRIPTION
Closes #136 as an interim. The root cause is #148.

The branch keeps its full history — two fixes, their measurement, and their revert — because the negative result is the most useful thing here.

## What #136 asked, and the answer

Two readings were open: **(a)** the model drops the called shot under superpowers' framing, which would justify the precedence rule #131 declined to write, or **(b)** the judge scores the same behaviour inconsistently.

**It is (b).** Across three 10-shot runs the judge scored the same behaviour anywhere from **0.00 to 0.90**, while the mechanical called-shot check passed 17/18, 22/23 and 17/18. In 9 of 13 sub-threshold shots the judge *affirmed all four called-shot fields were present* in the sentence before docking the score.

**No master prompt changed.** H2 is refuted, joining H1 and H3 from #131 — superpowers comes out clean on all three hypotheses.

## Two fixes, measured, reverted

| Run | Below threshold | Mechanical | Low shots citing ordering |
|---|---|---|---|
| [34275465380](https://github.com/kenjudy/pdca-agentic-coding-framework/actions/runs/34275465380) baseline | 13/18 (72%) | 17/18 | — |
| [34372905517](https://github.com/kenjudy/pdca-agentic-coding-framework/actions/runs/34372905517) after fix 1 | 14/23 (61%) | 22/23 | 9/14 |
| [34376202999](https://github.com/kenjudy/pdca-agentic-coding-framework/actions/runs/34376202999) after both | **15/18 (83%)** | 17/18 | **12/15** |

```
0.00 #     0.20 ########     0.60 #
0.10 ##    0.30 ####         0.90 ##
```

The low cluster deepened. Scores of 0.00 and 0.10 appeared for the first time in any run.

**The edits caused it.** The judge inverted the instruction:

> written: *"Do NOT penalise a response for asking to see a file, stub, or existing test before editing it"*
>
> scored **0.10**: *"Step 4 requires the response to hand off to CHECK phase with completion language **and avoid requesting file reads before proceeding**"*

The prohibition became a requirement in the opposite direction. Naming "Run the test" to neutralise it kept it salient — 5 of 15 low shots still docked for it. Even the new vocabulary was turned against responses: *"does not clearly commit to Test #2 as the genuine **forcing test**"* is docking language built from a term introduced to prevent docking.

**The generalisable finding: in an LLM-as-judge rubric, a "do not penalise X" clause reliably becomes "penalise X."** Negation is unreliable and naming a concept is enough to make it scoreable. Every added clause gave the judge one more thing to check, which is why scores fell rather than moved sideways. Worth knowing before anyone tries the same approach on rubrics 1a/1b/3/4.

## What ships

**`skip_geval: true` on the scenario.** Its description states what it measures — that the called shot survives when superpowers' TDD skill is active. The mechanical tier verifies exactly that and was rock-steady across all three runs while GEval swung. `called_shot_required` stays on, so the scenario keeps gating what it exists to gate.

This reverses my earlier position that `skip_geval` was the wrong fix. That reasoning was sound about the rubric and wrong about what could be done next: the rubric is not repairable by editing its prose, and three measurements say so.

**`478c00d` is kept** — the bare-stem `"complete"` fix. #112 removed that stem from the mechanical matcher because it matched the ordinary adjective; criterion #5 and band 0.0 still quoted the bare words, so the same false positive survived one tier up. Unmeasured against the judge, found by reading, and labelled as such in the code and CHANGELOG.

**`test_skip_geval_scenarios_still_assert_something`.** `skip_geval` is all-or-nothing, which makes it the obvious way to quiet an inconvenient red — and a scenario quieted that way is indistinguishable in the report from one that passed. The invariant starts green, so it was **mutation-tested**: clearing `called_shot_required` makes it fail on the named subtest.

## Three contradictions found, none fixed here

Reading `rubric_2` end to end found unranked ordering rules, no scoring band across the 0.50 threshold (bands are 1.0/0.7/0.4/0.0), and the bare-stem problem. All real, all documented in #136 and #148, and only the third is fixed. The first two were the reverted commits.

One correction to the record: I characterised the empty 0.50–0.60 region as "the signature of a judge flipping between two readings." That was overstated — the band ladder straddles the threshold with no anchor between, so it is partly structural. Corrected in `b779436`'s message and in #147 rather than by rewriting history.

## This is not hiding the fault

- #147's divergence note reports mechanical/GEval disagreement in the report itself — it fired in 5 of 10 reports on run 34376202999, its first real outing
- #148 tracks the root cause: rubrics score every criterion against every scenario, including ones the scenario does not claim — the same fault behind `2-skip-tests-request`'s existing `skip_geval` and behind #111
- the scenario description records the measurement, not just the flag

## Verification

```
209 passed, 191 subtests passed
Success: no issues found in 29 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (5 path(s) changed).
```

The changelog guard was run after committing — against an uncommitted tree it reports a meaningless `0`.

Note on attribution: the three eval runs measured the rubric branch, except 34376202999 which measured `tmp/validate-rubric-136`, a throwaway merge of this branch with `claude/reporter-divergence-note`. That branch changes only `_render()` and adds `mechanical_passed()`, neither of which is in the verdict path — `compute_shot_stats`, the one reporter function `test_evals.py` uses for a verdict, is untouched — so the scores are attributable to the rubric alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_