### PR TITLE
Report when the two scoring tiers disagree, not just when scores vary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,18 @@
   Unreleased` section exists, which stays true forever after one entry and is blind to the
   PR that forgot. Dependabot is exempt — its bumps are summarised once at release time.
 
+- **Eval reports now flag when the two scoring tiers disagree (#147).** The mechanical tier
+  confirms required strings are literally present; GEval judges semantically. When mechanical
+  passes and GEval fails — or the reverse — the judge scored something the rubric may not
+  declare, which is the fingerprint of a rubric fault rather than a scenario failure. Analyst
+  Notes previously flagged only variance (`stddev > 0.2`), and variance is the symptom *both*
+  candidate causes share, so it could never separate a flaky model from a flaky rubric. That
+  gap is what left #136 undiagnosed until a dispatched 10-shot run and a human reading
+  responses; the divergence there was 17/18 mechanical passes against 13/18 GEval failures,
+  both already printed on the same summary rows and never compared. The note is phrased as a
+  hypothesis pointing at specific recorded responses, not a verdict — a note that reads as a
+  finding would be #141's defect one level up. Costs nothing: no API calls, no extra run.
+
 - **Eval reports now record the dependency versions that produced them.** Every report
   gains an `**Environment:**` line naming the installed `deepeval` and `anthropic`
   versions, read via `importlib.metadata` so the reporter stays importable without the

--- a/skill/eval/reporter.py
+++ b/skill/eval/reporter.py
@@ -41,6 +41,17 @@ def compute_shot_stats(shot_scores: list[float]) -> dict:
     return {"shot_mean": round(mean, 4), "shot_stddev": round(stddev, 4)}
 
 
+def mechanical_passed(result: dict) -> bool:
+    """Whether the mechanical tier passed for a result, retried or not.
+
+    Was computed inline in two places with the same expression. Named because the
+    divergence note below turns it into a comparison rather than a display value.
+    """
+    if result.get("retried"):
+        return result["shots_mech_passed"] >= 2
+    return all(c.passed for c in result["mechanical"])
+
+
 PHASE_NAMES = {
     "1a": "Analysis",
     "1b": "Planning",
@@ -79,7 +90,7 @@ class EvalReporter:
         lines.append("|----------|-------|-------|-----------|-------|------------|")
         for r in self.results:
             phase = PHASE_NAMES.get(r["prompt_id"], r["prompt_id"])
-            mech_ok = r["shots_mech_passed"] >= 2 if r.get("retried") else all(c.passed for c in r["mechanical"])
+            mech_ok = mechanical_passed(r)
             if r.get("retried"):
                 mean = r.get("shot_mean")
                 stddev = r.get("shot_stddev")
@@ -160,19 +171,46 @@ class EvalReporter:
 
             lines.append("")
 
-        # Analyst notes: flag high-variance retried scenarios
+        # Analyst notes: flag high-variance retried scenarios, and scenarios where the
+        # two scoring tiers disagree.
         high_variance = [
             r for r in self.results
             if r.get("retried") and (r.get("shot_stddev") or 0.0) > 0.2
         ]
-        if high_variance:
+        # Mechanical confirms required strings are literally present; GEval judges
+        # semantically. When they disagree the judge scored something the rubric may not
+        # declare -- the fingerprint of a rubric fault rather than a scenario failure.
+        # In #136, 17 of 18 retry-shots passed mechanically while 13 of 18 fell below the
+        # GEval threshold, and both numbers sat on the same summary rows uncompared.
+        divergent = [
+            r for r in self.results
+            if mechanical_passed(r) != r["geval_passed"]
+        ]
+        if high_variance or divergent:
             lines.append("## Analyst Notes\n")
+        if high_variance:
             lines.append("The following scenarios show high score variance (stddev > 0.2) across retry shots.")
             lines.append("These may be flaky or sensitive to minor prompt wording changes.\n")
             for r in high_variance:
                 lines.append(
                     f"- **{r['scenario_id']}**: mean={r.get('shot_mean')}, stddev={r.get('shot_stddev')}"
                 )
+            lines.append("")
+
+        if divergent:
+            lines.append("**Mechanical/GEval divergence**\n")
+            lines.append(
+                "The two scoring tiers disagree on these scenarios. The mechanical tier "
+                "confirms the required strings are literally present; GEval judges "
+                "semantically. A disagreement means the judge scored something the rubric "
+                "may not declare, so this may be a rubric fault rather than a scenario "
+                "failure -- read the recorded response before treating it as either "
+                "(see #136).\n"
+            )
+            for r in divergent:
+                mech = "pass" if mechanical_passed(r) else "FAIL"
+                geval = "pass" if r["geval_passed"] else "FAIL"
+                lines.append(f"- **{r['scenario_id']}**: mechanical {mech}, GEval {geval}")
             lines.append("")
 
         return "\n".join(lines)

--- a/skill/tests/test_evals_reporter.py
+++ b/skill/tests/test_evals_reporter.py
@@ -327,3 +327,68 @@ class TestReportProvenance:
         '5 shot(s); 5 did not pass'."""
         content = EvalReporter().write_report(tmp_path / "empty.md").read_text()
         assert "deepeval" in content
+
+
+class TestDivergenceNote:
+    """Mechanical and GEval disagreeing is the fingerprint of a rubric fault (#147).
+
+    The mechanical tier confirms required strings are literally present in the response.
+    GEval judges semantically. When mechanical passes and GEval fails, the judge scored
+    something the rubric may not declare -- which is what happened in #136, where 17 of
+    18 retry-shots passed mechanically while 13 of 18 fell below the GEval threshold, and
+    9 of those 13 judge reasons affirmed the required fields were present before docking.
+
+    Both values are already on the same summary row. Nothing compared them.
+    """
+
+    def _report(self, tmp_path, *results):
+        reporter = EvalReporter()
+        for r in results:
+            reporter.add(r)
+        return reporter.write_report(tmp_path / "report.md").read_text()
+
+    def test_divergence_is_reported_when_mechanical_passes_but_geval_fails(self, tmp_path):
+        content = self._report(
+            tmp_path,
+            _make_result(geval_score=0.3, geval_passed=False, mechanical_pass=True),
+        )
+        assert "Mechanical/GEval divergence" in content
+
+    def test_divergent_scenario_is_named(self, tmp_path):
+        """A note that does not say which scenario cannot send anyone to a response."""
+        content = self._report(
+            tmp_path,
+            _make_result(scenario_id="2-first-step", geval_passed=False, mechanical_pass=True),
+        )
+        section = content[content.index("Mechanical/GEval divergence"):]
+        assert "2-first-step" in section
+
+    def test_divergence_is_reported_when_geval_passes_but_mechanical_fails(self, tmp_path):
+        """The reverse direction is equally diagnostic: the judge liked a response that
+        does not contain what the scenario requires."""
+        content = self._report(
+            tmp_path,
+            _make_result(geval_score=0.9, geval_passed=True, mechanical_pass=False),
+        )
+        assert "Mechanical/GEval divergence" in content
+
+    def test_no_divergence_note_when_both_tiers_agree(self, tmp_path):
+        """Agreement is the normal case and must stay silent, or the note becomes noise
+        that trains people to skip it."""
+        content = self._report(
+            tmp_path,
+            _make_result(geval_passed=True, mechanical_pass=True),
+            _make_result(scenario_id="2-first-step", geval_score=0.2,
+                         geval_passed=False, mechanical_pass=False),
+        )
+        assert "Mechanical/GEval divergence" not in content
+
+    def test_note_is_phrased_as_a_hypothesis_not_a_verdict(self, tmp_path):
+        """Per eval/README.md's materiality rule and #141: a note that reads as a finding
+        is the same defect one level up -- output that looks like a measurement."""
+        content = self._report(
+            tmp_path,
+            _make_result(geval_passed=False, mechanical_pass=True),
+        )
+        section = content[content.index("Mechanical/GEval divergence"):]
+        assert "recorded response" in section


### PR DESCRIPTION
Deliverable 1 of #147. Validated in the field before this PR was opened.

## The gap

Analyst Notes flags high variance:

```
The following scenarios show high score variance (stddev > 0.2) across retry shots.
- 2-superpowers-tdd-precedence: mean=0.6, stddev=0.3606
```

Variance is the symptom that **both** candidate causes of a flaky scenario share. It cannot separate *the model behaves inconsistently* from *the judge scores the same behaviour inconsistently* — opposite findings needing opposite fixes, a prompt rule versus a rubric fix.

#136 was filed precisely because that note could not answer the question. It then sat undiagnosed until a dispatched 10-shot run plus a human reading sub-threshold responses by hand.

## The signal that could answer it was already in the report

The mechanical tier confirms the required strings are literally present. GEval judges semantically. When they disagree systematically, the judge is scoring against something the rubric does not declare — which is what an instrument fault looks like, as opposed to a scenario failure.

On [run 34275465380](https://github.com/kenjudy/pdca-agentic-coding-framework/actions/runs/34275465380), 18 retry-shots:

| | |
|---|---|
| Mechanical passed | **17 / 18** |
| GEval below threshold | **13 / 18** |
| Sub-threshold judge reasons affirming all four called-shot fields present before docking | **9 / 13** |

`reporter.py` already held both values, in the same loop, on the same summary row, and never compared them:

```python
mech_ok = r["shots_mech_passed"] >= 2 if r.get("retried") else all(c.passed for c in r["mechanical"])
...
f" | {'✅' if r['geval_passed'] else '❌'} | {'✅' if mech_ok else '❌'} |"
```

**No API calls, no extra run** — arithmetic on data already in hand.

## Output

```
## Analyst Notes

**Mechanical/GEval divergence**

The two scoring tiers disagree on these scenarios. The mechanical tier confirms the
required strings are literally present; GEval judges semantically. A disagreement means
the judge scored something the rubric may not declare, so this may be a rubric fault
rather than a scenario failure -- read the recorded response before treating it as
either (see #136).

- **2-superpowers-tdd-precedence**: mechanical pass, GEval FAIL
```

Deliberately a hypothesis pointing at specific recorded responses, not a verdict. `eval/README.md`'s materiality rule already says to diagnose from the response rather than the pass rate; this says *which* responses. A note reading as a finding would be #141's defect one level up — output that looks like a measurement.

## Validated before this PR existed

The note **fired in 5 of 10 reports** on [run 34376202999](https://github.com/kenjudy/pdca-agentic-coding-framework/actions/runs/34376202999), its first real outing, correctly flagging the mechanical-passes/GEval-fails split that #136 turned out to be.

It would have fired on #131's original 5-shot run — the cycle that *introduced* the scenario. Analyst Notes said "may be flaky"; this would have said "mechanical passes, GEval fails — suspect the rubric." #136 need not have existed.

## Testing

**RED first:** 4 of 5 assertions failed on the missing note.

The fifth is a negative assertion — "no note when both tiers agree" — and **passed vacuously**, since the string it forbids did not yet exist. A negative assertion written before the feature is exactly the shape of green this repo distrusts, so it was **mutation-tested**: replacing `mechanical_passed(r) != r["geval_passed"]` with `not mechanical_passed(r) or not r["geval_passed"]` makes it fail, confirming it guards *the tiers disagree* against *something failed* rather than passing for want of a string.

Also extracts `mechanical_passed()`. The same expression was computed inline in two places; naming it turns a display value into a comparison.

## Scope

#147's second signal — bimodal scores clustering either side of the threshold — is **not** implemented and cannot be here. `tests/test_evals.py`'s `reporter` fixture is `scope="session"`, so each `run-evals.sh` invocation writes its own report holding at most 3 retry-shots for a scenario, and 3 points cannot show a mode. The bimodality in #136 was visible only across 10 separate reports. #147 has been corrected to record that and split it into a separate deliverable needing a cross-report aggregator.

#147 also carries a second correction relevant here: the empty band at the threshold turned out to be *partly structural* — the scoring bands are 1.0/0.7/0.4/0.0 against a 0.50 threshold — not pure judge instability as first claimed. So a future bimodality detector must not report "judge instability" as a conclusion; it can report the shape and point at the responses.

## Verification

```
211 passed, 189 subtests passed
Success: no issues found in 28 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (3 path(s) changed).
```

Measured after committing — the guard diffs committed state and reports a meaningless `0` otherwise.

## Related

- #147 — this issue; deliverable 2 remains open
- #136 — the diagnosis that motivated it, closed by #149
- #148 — the root cause this note detects instances of

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_