### PR TITLE
The repo's first tracked eval baseline, and instructions that point at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@
   obvious abuse — a scenario with GEval off and no mechanical signal cannot fail, and would
   report as a pass forever.
 
+- **Two instruction files told readers to get baseline scores from a directory git has never
+  tracked (#122).** `CLAUDE.md`'s Validating Prompt Changes step 1 and
+  `SUPERVISION-PROTOCOL.md`'s "Establish a Baseline" both pointed at `skill/eval/results/`,
+  which is gitignored (`.gitignore:28`) and whose `git log --all` is empty. Both instructions
+  have therefore been inoperable on every fresh clone and in CI for as long as they have
+  existed — and #122's own closing procedure, "compare against the baselines in
+  `skill/eval/results/`", had no left-hand side. New tracked `skill/eval/baselines/` holds
+  deliberately promoted reports; `results/` is deliberately **not** un-ignored, because every
+  run writes a fresh timestamped report there and tracking it would dirty the tree after each
+  run — the churn pattern `uv.lock` already produced.
+- `test_baselines_dir_is_not_gitignored` runs `git check-ignore` and fails if anyone adds the
+  new directory to `.gitignore`, which would reproduce the defect silently while both
+  instructions carried on reading as though they worked.
+
 - **The Phase 2 judge could dock the bare word "complete", which #112 had already fixed in the
   mechanical tier.** #112 removed the stem from `must_not_contain` because it matched the ordinary
   adjective — *"here's the complete sequence"* is the behaviour the prompt asks for. Criterion #5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@
   obvious abuse — a scenario with GEval off and no mechanical signal cannot fail, and would
   report as a pass forever.
 
+- **The repo has a tracked eval baseline for the first time (#122).** `skill/eval/baselines/`
+  now holds a full 21-scenario sweep run at `deepeval 4.2.2` / `anthropic 1.4.0`, recorded in
+  the report itself by #145's provenance line — making it the first eval run in the project's
+  history that can be attributed to a dependency set. 20 of 21 scenarios pass;
+  `4-tdd-breakdown` is a known red tracked in #151 and is labelled as such, so a future
+  comparison can tell it from a regression. `test_baseline_exists_for_every_scenario` requires
+  every scenario in `eval/scenarios/` to appear in some baseline, so adding a scenario without
+  baselining it now fails the suite.
+- **#147's divergence note found a new instance on its first full sweep.** It flagged
+  `4-tdd-breakdown` — mechanical passing, GEval failing — in rubric 4, which nobody had
+  examined. That is the third rubric implicated in #148's root cause, after rubric 2 (#136)
+  and rubric 3 (#111).
+
 - **Two instruction files told readers to get baseline scores from a directory git has never
   tracked (#122).** `CLAUDE.md`'s Validating Prompt Changes step 1 and
   `SUPERVISION-PROTOCOL.md`'s "Establish a Baseline" both pointed at `skill/eval/results/`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,16 @@ See `skill/SUPERVISION-PROTOCOL.md` for the full protocol. Key rules:
 
 Any edit to master prompt files or eval rubrics requires:
 
-1. Check `skill/eval/results/` for the baseline scores
+1. Check `skill/eval/baselines/` for the baseline scores. This directory is **tracked**;
+   `skill/eval/results/` is gitignored and holds only your own last local run, so it is
+   empty on a fresh clone and in CI.
 2. Make one discrete change, rebuild (`bash skill/build-skill.sh`)
 3. Re-run only the affected phase evals
 4. All previously passing scenarios must still pass — see `skill/SUPERVISION-PROTOCOL.md` for the full table of phase → eval class mappings
+
+**Read the baseline's caveats before comparing against it.** Each baseline records the
+`deepeval` and `anthropic` versions that produced it, and scores are not comparable across
+a major bump. GEval scores for prompt 2 and prompt 3 are **provisional**: the Phase 2
+rubric was measured scoring identical behaviour anywhere from 0.00 to 0.90 (#136), and
+#148 tracks the cause. Mechanical checks were steady across every run and are the reliable
+gate.

--- a/skill/SUPERVISION-PROTOCOL.md
+++ b/skill/SUPERVISION-PROTOCOL.md
@@ -138,13 +138,22 @@ Any change to master prompt files (`1. Plan/`, `2. Do/`, etc.) or eval rubrics m
 
 ### 1. Establish a Baseline
 
-Check the most recent eval report:
+Check the tracked baselines first:
 
 ```bash
-ls -t skill/eval/results/
+ls -t skill/eval/baselines/
 ```
 
-If a recent report exists, use its per-scenario scores as the baseline. If not, or if the codebase has diverged, run the full eval first:
+`skill/eval/baselines/` holds deliberately promoted reports and is committed, so it works
+on a fresh clone and in CI. `skill/eval/results/` is gitignored — it holds only your own
+most recent local run, and is empty for anyone who has not just run the evals themselves.
+That is why the instruction here used to point at nothing (#122).
+
+```bash
+ls -t skill/eval/results/   # your own last local run, if any
+```
+
+Use the per-scenario scores as the baseline. If not, or if the codebase has diverged, run the full eval first:
 
 ```bash
 cd skill && bash run-evals.sh

--- a/skill/eval/baselines/README.md
+++ b/skill/eval/baselines/README.md
@@ -1,0 +1,45 @@
+# Eval baselines
+
+Tracked, deliberately promoted eval reports. `CLAUDE.md`'s Validating Prompt Changes step 1
+and `SUPERVISION-PROTOCOL.md`'s "Establish a Baseline" both point here.
+
+## Why this is not `eval/results/`
+
+`skill/eval/results/` is gitignored (`.gitignore:28`) and **has never been tracked** —
+`git log --all` over that path returns nothing. Both instructions above used to point at
+it, which meant they were inoperable on every fresh clone and in CI, and #122's closing
+procedure ("compare against the baselines in `skill/eval/results/`") had no left-hand side.
+
+`results/` cannot simply be un-ignored: every run writes a fresh timestamped report there,
+so tracking it would leave the working tree dirty after each run — the churn pattern
+`uv.lock` already produced. This directory holds only reports someone chose to promote.
+
+## Promoting a report
+
+```bash
+cd skill && bash run-evals.sh tests/test_evals.py      # or dispatch evals.yml
+cp eval/results/report_<timestamp>.md eval/baselines/
+```
+
+Promote a **full sweep**, not a single scenario — `test_baseline_exists_for_every_scenario`
+requires every scenario in `eval/scenarios/` to appear in some baseline here.
+
+## Reading a baseline
+
+**Check the `**Environment:**` line first.** Every report records the `deepeval` and
+`anthropic` versions that produced it (#145). Scores are not comparable across a major
+dependency bump, and a report without that line predates the mechanism — treat its numbers
+as unattributable, which is precisely why #122 could not be answered in retrospect.
+
+**Mechanical checks are the reliable gate.** They were steady across every measured run
+(17/18, 22/23, 17/18 on the #136 diagnostic).
+
+**GEval scores for prompts 2 and 3 are provisional.** The Phase 2 rubric was measured
+scoring identical behaviour anywhere from 0.00 to 0.90 (#136); two attempts to fix it by
+editing the rubric made it worse and were reverted. #148 tracks the cause — rubrics score
+every criterion against every scenario, including ones the scenario does not claim.
+`2-superpowers-tdd-precedence` and `2-skip-tests-request` therefore carry `skip_geval`, and
+#111 records the same class of problem in prompt 3.
+
+Do not treat a prompt-2 or prompt-3 GEval delta as a regression without reading the
+recorded responses, per `eval/README.md`'s materiality rule.

--- a/skill/eval/baselines/README.md
+++ b/skill/eval/baselines/README.md
@@ -43,3 +43,12 @@ every criterion against every scenario, including ones the scenario does not cla
 
 Do not treat a prompt-2 or prompt-3 GEval delta as a regression without reading the
 recorded responses, per `eval/README.md`'s materiality rule.
+
+## Known reds in the current baseline
+
+`report_20260909_174245.md` — 20 of 21 scenarios pass. **`4-tdd-breakdown` is red**
+(GEval 0/3 shots, mechanical 3/3) and is tracked in #151: at least one shot shows the judge
+scoring only the first line of a 1553-character response and reporting that the body was
+absent. Treat it as a known red, not as a regression you introduced.
+
+`4-short-session` carries high variance (mean 0.5667, stddev 0.3215) and passes on the mean.

--- a/skill/eval/baselines/report_20260909_174245.md
+++ b/skill/eval/baselines/report_20260909_174245.md
@@ -1,0 +1,2748 @@
+# PDCA Eval Report — 2026-09-09 17:42:45
+
+**Environment:** deepeval: 4.2.2, anthropic: 1.4.0
+
+## Summary
+
+| Scenario | Phase | Score | Threshold | GEval | Mechanical |
+|----------|-------|-------|-----------|-------|------------|
+| 1a-clear-goal | Analysis | 0.90 | 0.50 | ✅ | ✅ |
+| 1a-vague-goal | Analysis | 0.90 | 0.50 | ✅ | ✅ |
+| 1a-external-api | Analysis | 0.90 | 0.50 | ✅ | ✅ |
+| 1b-clear-analysis | Planning | 0.80 | 0.50 | ✅ | ✅ |
+| 1b-needs-refactoring | Planning | 0.90 | 0.50 | ✅ | ✅ |
+| 1b-multi-system | Planning | 0.90 | 0.50 | ✅ | ✅ |
+| 2-first-step | TDD Implementation | 0.70 | 0.50 | ✅ | ✅ |
+| 2-skip-tests-request | TDD Implementation | n/a | 0.00 | ✅ | ✅ |
+| 2-beads-ordering-capture | TDD Implementation | 0.80 | 0.50 | ✅ | ✅ |
+| 2-after-passing-test | TDD Implementation | 0.8667 ± 0.0577 | 0.50 | ✅ | ✅ |
+| 2-ponytail-precedence | TDD Implementation | 1.00 | 0.50 | ✅ | ✅ |
+| 2-superpowers-branch-finish | TDD Implementation | 1.00 | 0.50 | ✅ | ✅ |
+| 2-superpowers-tdd-precedence | TDD Implementation | n/a | 0.00 | ✅ | ✅ |
+| 3-all-complete | Verification | 1.00 | 0.50 | ✅ | ✅ |
+| 3-todos-remaining | Verification | 0.90 | 0.50 | ✅ | ✅ |
+| 3-missing-documentation | Verification | 1.00 | 0.50 | ✅ | ✅ |
+| 3-critic-pass-missing | Verification | 0.90 | 0.50 | ✅ | ✅ |
+| 3-superpowers-verification-not-check | Verification | 0.90 | 0.50 | ✅ | ✅ |
+| 4-successful-session | Retrospection | 0.70 | 0.50 | ✅ | ✅ |
+| 4-tdd-breakdown | Retrospection | 0.2 ± 0.1 | 0.50 | ❌ | ✅ |
+| 4-short-session | Retrospection | 0.5667 ± 0.3215 | 0.50 | ✅ | ✅ |
+
+## Scenario Details
+
+### 1a-clear-goal (Analysis)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'gem 'rack-attack''` — 'gem 'rack-attack'' absent (good) in output
+- ✅ `must_not_contain: 'add the following code'` — 'add the following code' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong adherence to all evaluation steps. It explicitly maps concrete codebase searches before analysis (SEARCH 1-3: rack-attack gem presence, authentication patterns, cache configuration), avoiding premature solutions. The output flags critical blocking unknowns (authentication mechanism, Redis availability, response format) rather than assuming defaults. No code snippets or library recommendations are provided; instead, the response maintains a discovery-oriented tone with targeted clarifying questions grounded in specific technical concerns (e.g., 'wrong key = rate limiting doesn't work'). The architecture pattern discovery correctly identifies touch points (Gemfile, config/initializers, controllers) without prescribing implementation. The only minor gap is that the response could slightly tighten the distinction between \"what searches would reveal\" versus \"what we need to ask,\" though the current framing remains effective and exploratory. The complexity assessment and blocking constraint framing are particularly strong.
+
+**Input:**
+
+```
+I need to add rate limiting to our Rails API. We use Devise for authentication and the API is versioned under /api/v1/. I want to limit requests to 100 per hour per user.
+```
+
+**Model output:**
+
+```
+I'll analyze this systematically before making recommendations.
+
+## Architecture Pattern Discovery
+
+Since no codebase is directly available, I'll map what I would search for and what questions need answers before planning.
+
+---
+
+### SEARCH 1: Similar Feature Implementations
+**What I'd search for:** `rack-attack`, `throttle`, `rate_limit`, `api_throttle`
+
+**What I'd expect to find in a typical Rails/Devise API:**
+- Presence or absence of `rack-attack` gem in `Gemfile`
+- Any existing `config/initializers/rack_attack.rb`
+- Middleware stack configuration in `config/application.rb`
+
+**Key question:** Is `rack-attack` already in the stack, or are we adding it fresh?
+
+---
+
+### SEARCH 2: Integration Patterns
+**What I'd search for:** How `current_user`, Devise authentication, and API controllers connect
+
+**What I'd expect to find:**
+- A base controller, likely `Api::V1::BaseController` or `ApplicationController`
+- Devise auth hooks: `before_action :authenticate_user!`
+- How the authenticated user identity is surfaced (session? JWT? token?)
+
+**Critical unknown:** How is the user identified per request?
+- Session cookie (Devise default)
+- JWT (common with APIs)
+- API token (custom header)
+
+This determines what Rack::Attack uses as the discriminator key.
+
+---
+
+### SEARCH 3: Configuration Patterns
+**What I'd search for:** Existing initializers, `config/application.rb` middleware inserts, any existing Redis/Memcache configuration
+
+**Key questions:**
+- Is Redis already in the stack? (`redis` gem, `Sidekiq`, `ActionCable`, `kredis`)
+- Or is the cache store the default memory store?
+
+This is a **blocking constraint** — the rate limit counter must be stored somewhere durable. Memory store won't work across dynos/processes.
+
+---
+
+## Architectural Implications
+
+**Established layers in a typical Rails/Devise API:**
+```
+config/initializers/          ← middleware configuration lives here
+app/controllers/api/v1/       ← versioned controllers
+app/controllers/application_controller.rb
+Gemfile / Gemfile.lock
+```
+
+**Integration touch points:**
+1. `Gemfile` — add `rack-attack` if not present
+2. `config/application.rb` — may need `config.middleware.use Rack::Attack`
+3. `config/initializers/rack_attack.rb` — throttle rules
+4. `config/environments/test.rb` — disable or stub in test environment
+
+---
+
+## Key Unknowns (Must Resolve Before Planning)
+
+| # | Unknown | Why It Blocks |
+|---|---------|---------------|
+| 1 | **Authentication mechanism** (session/JWT/token) | Determines the throttle key — wrong key = rate limiting doesn't work or locks out everyone |
+| 2 | **Redis availability** | Determines cache store; memory store breaks in multi-process/multi-dyno deployments |
+| 3 | **Is `rack-attack` already installed?** | Determines scope of work |
+| 4 | **Authenticated-only or also unauthenticated requests?** | 100/hr per user is clear; do anonymous requests also need limiting? |
+| 5 | **Response format on limit hit** | API clients expect JSON `429`, not an HTML Rack response — needs custom error body |
+
+---
+
+## Complexity Assessment
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Implementation Complexity | Low–Medium | Well-established gem with clear Rails integration |
+| Pattern Clarity | Moderate | Depends heavily on auth mechanism answer |
+| Context Scope | Narrow | 2–4 files touched |
+| Debugging Likelihood | Medium | Auth key extraction and Redis config are common failure points |
+| External System Integration | Simple–Complex | Simple if Redis exists; complex if cache store needs changing |
+
+---
+
+## Clarifying Questions Needed
+
+1. **How does your API authenticate requests?** (`Authorization: *** Devise session cookie, custom `X-API-Key` header?)
+2. **Is Redis in your stack?** (Check `Gemfile` for `redis`, `sidekiq`, `kredis`, or `hiredis`)
+3. **Is `rack-attack` already in your `Gemfile`?**
+4. **Do unauthenticated requests to `/api/v1/` need limiting too**, or only authenticated ones?
+5. **What should the 429 response body look like?** (e.g., `{ \"error\": \"Rate limit exceeded\" }` with `Retry-After` header?)
+
+Once these are answered, the plan becomes straightforward and low-risk. The auth mechanism question in particular is **blocking** — the entire throttle key strategy depends on it.
+```
+
+### 1a-vague-goal (Analysis)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'Here is the implementation'` — 'Here is the implementation' absent (good) in output
+- ✅ `must_not_contain: 'Add an index'` — 'Add an index' absent (good) in output
+
+**Judge reasoning:**
+
+> The Actual Output excellently addresses Evaluation Step 1 by correctly identifying vagueness in the Input ('I want to improve performance' lacks technical context) and asking highly targeted clarifying questions. The questions systematically cover language/framework (implied by 'codebase'), system name/domain, specific problem type (response times, memory, CPU, build, database, network), pain point identification (bottleneck location), how the issue was identified (measurements/profiling data), and constraints (architecture flexibility). The output explicitly avoids proposing solutions, libraries, or code. Step 2 is partially addressed: the output correctly indicates that codebase searches cannot proceed without sufficient context, though it doesn't name specific search patterns to execute once context is provided. Step 3 is fully met—no concrete solutions or library recommendations are suggested. Step 4 is not directly addressed, as no external system assumptions are flagged for validation. The response demonstrates strong alignment with steps 1 and 3, partial alignment with step 2, and no alignment with step 4.
+
+**Input:**
+
+```
+I want to improve performance.
+```
+
+**Model output:**
+
+```
+I need more context before I can help with performance improvement. Let me ask some clarifying questions first.
+
+**What I need to know:**
+
+1. **What codebase/system are we working with?** No files or project context have been shared in this conversation.
+
+2. **What kind of performance problem?**
+   - Slow response times?
+   - High memory usage?
+   - High CPU usage?
+   - Slow build times?
+   - Database query performance?
+   - Network latency?
+
+3. **Where is the bottleneck observed?**
+   - A specific function, endpoint, query, or operation?
+   - Or is this exploratory — you suspect a problem but haven't profiled yet?
+
+4. **Do you have measurements?**
+   - Profiler output?
+   - Benchmark results?
+   - User reports of slowness?
+   - Or starting from zero?
+
+5. **What constraints exist?**
+   - Can we change the architecture, or only optimize within existing structure?
+   - Is this a hot path that can't be refactored, or greenfield optimization?
+
+---
+
+**Without a codebase and a specific performance problem, I cannot:**
+- Search for existing patterns
+- Identify bottlenecks
+- Recommend approaches grounded in evidence
+
+Please share the relevant context — either paste the codebase, describe the system, or share profiling data — and I'll run the mandatory pattern discovery steps before any analysis.
+```
+
+### 1a-external-api (Analysis)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'stripe.customers.create'` — 'stripe.customers.create' absent (good) in output
+- ✅ `must_not_contain: 'npm install stripe'` — 'npm install stripe' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong alignment with all evaluation steps. Step 1: The input is sufficiently specific (Node.js/Express, Stripe API, existing PayPal integration), but the response appropriately acknowledges codebase unavailability and pivots to documenting targeted searches with specific file locations and query intent. Step 2: The response explicitly identifies a STOP CONDITION ('No codebase is available') and lists three concrete, actionable searches (payment feature implementations, integration patterns, configuration patterns) with specific file paths and queries before any analysis. Step 3: The response correctly identifies architecture patterns and integration points to discover (abstraction layers, webhook patterns, config loading, ORM usage) without proposing specific libraries or code implementations—it defers solutions with phrases like 'determine where Stripe code should live' and 'Blocks TDD execution plan' rather than prescribing implementations. Step 4: The response explicitly flags assumptions about external systems (Stripe webhooks, signature verification, Stripe.js frontend) and marks them for validation in the 'Unknowns' and 'Clarifying Questions' sections. The 11 blocking questions are highly targeted and directly address technology stack, pain points, and discovery gaps. Minor: The response includes some architectural framing (e.g., the complexity table) that edges toward analysis rather than pure discovery, but this remains grounded in questions rather than prescriptions.
+
+**Input:**
+
+```
+I need to integrate with the Stripe API to handle subscription billing. We have a Node.js/Express app and currently use PayPal for one-time payments.
+```
+
+**Model output:**
+
+```
+# Analysis Phase: Stripe Subscription Billing Integration
+
+## Architecture Pattern Discovery
+
+**No codebase is available in the conversation context**, so I'll document what I would search for rather than fabricate findings.
+
+### Searches I Would Run
+
+**SEARCH 1** — Similar payment feature implementations:
+- Files to look for: `paypal.js`, `paypal/`, `payment.js`, `billing.js`, anything in `services/`, `lib/`, or `integrations/`
+- Query: \"How does PayPal payment processing work in the codebase?\"
+
+**SEARCH 2** — Integration patterns:
+- Files to look for: Express route files (`routes/`), middleware (`middleware/`), controllers (`controllers/payment`)
+- Query: \"Where are PayPal webhooks and payment routes integrated with the Express app?\"
+
+**SEARCH 3** — Configuration patterns:
+- Files to look for: `config/`, `.env.example`, `constants.js`, any secrets/key loading patterns
+- Query: \"How are PayPal credentials and API keys configured and accessed?\"
+
+---
+
+## Clarifying Questions (Blocking)
+
+Before I can scope this properly, I need answers to several unknowns:
+
+### About the Existing Codebase
+1. **Where does PayPal code live?** (e.g., `services/paypal.js`, `routes/payment.js`, a dedicated module?) — this determines where Stripe code should live
+2. **Is there an abstraction layer** (e.g., a `PaymentProvider` interface or generic `charge()` function), or is PayPal called directly from routes/controllers?
+3. **How is config loaded?** dotenv, a config module, secrets manager?
+4. **Is there a database ORM in use?** (Sequelize, Prisma, Mongoose, etc.) — needed for subscription/customer record modeling
+
+### About the Requirements
+5. **What subscription behaviors are needed?**
+   - Trial periods?
+   - Multiple plans/tiers?
+   - Mid-cycle upgrades/downgrades (proration)?
+   - Cancellation with access until period end vs. immediate?
+6. **What should happen to existing PayPal users?** Keep PayPal running in parallel, or migrate everyone?
+7. **Which Stripe objects matter most?** Customer, Subscription, PaymentMethod, Invoice — all of these, or a subset?
+8. **Are webhooks required now?** (e.g., `invoice.paid`, `customer.subscription.deleted`) — these are nearly always needed for reliable billing
+9. **Do you have a Stripe account and test keys already?**
+
+### About the Team/Process
+10. **Is there an existing test suite?** (Jest, Mocha, Supertest?) — critical for TDD execution
+11. **Is there a CI pipeline that must stay green?**
+
+---
+
+## Problem Understanding
+
+### Scope
+Integrate Stripe's subscription billing API into an existing Node.js/Express app that already processes PayPal one-time payments. The two payment systems will likely coexist, at least initially.
+
+### Core Work Areas
+
+| Area | What's Involved |
+|---|---|
+| Stripe SDK setup | Install `stripe` npm package, configure credentials |
+| Customer management | Create/retrieve Stripe Customer objects tied to your user records |
+| Payment method collection | Stripe Elements or Payment Intents on the frontend |
+| Subscription lifecycle | Create, update, cancel subscriptions via API |
+| Webhook handling | Verify signatures, handle `invoice.paid`, `subscription.deleted`, etc. |
+| Database changes | Store `stripe_customer_id`, subscription status, plan info per user |
+| Parallel operation | Keep PayPal working for existing one-time payment flows |
+
+### Key Challenges
+
+1. **Webhook reliability** — Stripe's event-driven model means your backend must handle async events (e.g., payment failure, renewal) correctly. This is the most common integration failure point.
+2. **Idempotency** — Stripe webhooks can arrive more than once. Handlers must be idempotent.
+3. **Secret handling** — Webhook signature verification requires the raw request body, which conflicts with Express's JSON body parser if not configured carefully.
+4. **Frontend touchpoint** — Stripe requires client-side JS (Stripe.js) for PCI-compliant card collection. This is out of scope for a pure backend plan but must be coordinated.
+5. **PayPal coexistence** — Without an abstraction layer, two payment systems in the same routes creates tangled logic quickly.
+
+### Unknowns That Must Be Resolved First
+
+| Unknown | Why It Blocks |
+|---|---|
+| Does a payment abstraction exist? | Determines whether to add a new provider or refactor first |
+| What database/ORM is in use? | Blocks data model design |
+| Which subscription behaviors are required? | Determines Stripe API surface needed |
+| Webhook requirements? | Determines ~40% of the backend work |
+| Test framework? | Blocks TDD execution plan |
+
+---
+
+## Complexity Assessment
+
+| Dimension | Rating | Rationale |
+|---|---|---|
+| Implementation Complexity | **High** | Stripe subscriptions involve multiple coordinated API objects; webhook handling is non-trivial |
+| Pattern Clarity | **Ambiguous** | Unknown whether a payment abstraction exists to extend or routes need restructuring first |
+| Context Scope | **Broad** | Touches config, DB models, routes, middleware, potentially frontend |
+| Debugging Likelihood | **High** | External API + async webhooks = significant investigation surface |
+| External System Integration | **Complex** | Stripe API + webhook signature verification + Stripe.js frontend |
+
+---
+
+## Recommended Next Step
+
+Answer the clarifying questions above — particularly **#1–4** (codebase structure) and **#5–8** (subscription requirements). With those answers, I can:
+
+1. Identify whether preparatory refactoring (extracting a payment provider abstraction) is needed before any Stripe code is written
+2. Produce a concrete, numbered implementation plan with atomic TDD steps
+3. Correctly scope the webhook handler and database migration work
+```
+
+### 1b-clear-analysis (Planning)
+
+**GEval:** 0.80 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'def deliver_webhook'` — 'def deliver_webhook' absent (good) in output
+- ✅ `must_not_contain: 'rails generate'` — 'rails generate' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong structural compliance with the evaluation steps. It correctly identifies the request as a PDCA Planning Phase (prompt 1b) and delivers numbered atomic steps (1–5) with explicit feat: tagging. The test list is comprehensive, enumerating golden path (2xx/5xx responses, matching event types), degenerate cases (4xx non-retriable, timeouts), and exceptions (network failures). Abstraction level is appropriate: method names (e.g., `signature(payload, secret)`), schema references (`status`, `response_code` columns), and ASCII integration diagrams are used as context only, not runnable code. Acceptance criteria and definition of done are stated for each step, and test list items map to step acceptance criteria (e.g., \"Posts to subscriber URL\" maps to Step 2 acceptance criteria). Traceability is explicit. Key strengths: risk flagging (Step 3 column existence, Step 5 record creation), rollback strategy, and decision points (\"verify before coding\"). Minor shortcoming: the response does not explicitly tag a preparatory refactor step (though it correctly states none required), which slightly weakens Step 2 compliance regarding refactor/feat ordering convention. The note \"⚠️ Risk area\" in Step 3 somewhat conflates implementation concern with planning rigor, though this is minor. Overall, the plan is actionable and traceably aligned with test behaviors.
+
+**Input:**
+
+```
+Analysis complete. We need to add webhook delivery to our Rails app. WebhookDelivery model already exists (persists event_type and payload). We need to: (1) add HTTP delivery logic (POST to subscriber URL with HMAC signature), (2) add retry via existing Sidekiq worker pattern, (3) hook into existing EventBus subscription. No preparatory refactoring needed — existing abstractions fit cleanly.
+```
+
+**Model output:**
+
+```
+# Implementation Plan: Webhook Delivery
+
+Based on your analysis, here's a TDD-optimized plan for the three implementation areas.
+
+---
+
+## Integration Map
+
+```
+EventBus.publish(event) 
+  → WebhookSubscription lookup 
+  → WebhookDeliveryWorker.perform_async 
+  → WebhookDeliveryService.call (HTTP POST + HMAC)
+  → WebhookDelivery#update (status, response)
+```
+
+---
+
+## Test List (full behavioral inventory)
+
+**HTTP Delivery (WebhookDeliveryService)**
+- Posts to subscriber URL with correct payload
+- Sets `Content-Type: application/json` header
+- Sets `X-Webhook-Signature` HMAC-SHA256 header
+- Records `delivered` status on 2xx response
+- Records `failed` status on 4xx/5xx response
+- Records `failed` status on network timeout
+- Captures response code and body on WebhookDelivery record
+
+**Retry (WebhookDeliveryWorker)**
+- Enqueues with correct job arguments
+- Calls WebhookDeliveryService on perform
+- Retries on raised error (Sidekiq retry config)
+- Does not retry on 4xx (non-retriable failure)
+
+**EventBus Hook**
+- Subscription fires on matching event type
+- Does not fire on unrelated event type
+- Enqueues worker with delivery ID
+
+---
+
+## Preparatory Refactoring
+
+None required — confirmed by analysis.
+
+---
+
+## Implementation Steps
+
+---
+
+### Step 1 — `WebhookDeliveryService`: HMAC signature generation
+**Tag:** `feat: add HMAC signature helper to WebhookDeliveryService`
+**Model fit:** Low complexity, single method
+
+**Test:** Given a payload string and secret, `WebhookDeliveryService.signature(payload, secret)` returns `sha256=<hex-digest>`
+
+**Acceptance criteria:**
+- Method exists as a class method
+- Uses `OpenSSL::HMAC.hexdigest` with SHA256
+- Prefix is `sha256=`
+- Test passes with known fixture values
+
+**Files touched:** `app/services/webhook_delivery_service.rb` (new), `spec/services/webhook_delivery_service_spec.rb` (new)
+
+---
+
+### Step 2 — `WebhookDeliveryService`: HTTP POST with headers
+**Tag:** `feat: HTTP POST delivery with HMAC header`
+**Model fit:** Medium — requires stubbing HTTP
+
+**Test:** Given a `WebhookDelivery` record with a subscriber URL, `.call(delivery)` POSTs JSON payload with `Content-Type` and `X-Webhook-Signature` headers
+
+**Acceptance criteria:**
+- Uses existing HTTP client pattern in codebase (verify before coding)
+- Sends `delivery.payload` as JSON body
+- Signature header matches `signature(body, subscriber.secret)`
+- Stub with WebMock or VCR per existing test pattern
+
+**Files touched:** `app/services/webhook_delivery_service.rb`, `spec/services/webhook_delivery_service_spec.rb`
+
+---
+
+### Step 3 — `WebhookDeliveryService`: status recording
+**Tag:** `feat: record delivery status and response on WebhookDelivery`
+**Model fit:** Low complexity
+
+**Tests:**
+- 2xx response → `delivery.update(status: :delivered, response_code: 200)`
+- 5xx response → `delivery.update(status: :failed, response_code: 500)`
+- Timeout → `delivery.update(status: :failed, response_code: nil)` and re-raises
+
+**Acceptance criteria:**
+- `WebhookDelivery` has `status`, `response_code`, `response_body` columns (add migration if missing — make this explicit)
+- 4xx does NOT re-raise (non-retriable, sets failed and returns)
+- 5xx re-raises to trigger Sidekiq retry
+
+**Files touched:** `app/services/webhook_delivery_service.rb`, `spec/services/webhook_delivery_service_spec.rb`, migration if needed
+
+> ⚠️ **Risk area:** Confirm column existence before Step 3. If migration needed, it becomes Step 2.5 — stop and split.
+
+---
+
+### Step 4 — `WebhookDeliveryWorker`: enqueue and perform
+**Tag:** `feat: add WebhookDeliveryWorker with Sidekiq retry`
+**Model fit:** Low — follow existing worker pattern exactly
+
+**Tests:**
+- `.perform_async(delivery_id)` enqueues correctly (use `have_enqueued_sidekiq_job` or equivalent per codebase pattern)
+- `#perform(delivery_id)` loads record and calls `WebhookDeliveryService.call`
+- Worker declared with `sidekiq_options retry: 5` (or match existing retry convention)
+
+**Acceptance criteria:**
+- Worker class follows existing worker file/naming convention (check before creating)
+- Non-retriable 4xx: service returns without raising, worker completes normally
+- Retriable 5xx: service raises, Sidekiq handles retry
+
+**Files touched:** `app/workers/webhook_delivery_worker.rb` (new), `spec/workers/webhook_delivery_worker_spec.rb` (new)
+
+---
+
+### Step 5 — `EventBus` subscription
+**Tag:** `feat: subscribe WebhookDeliveryWorker to EventBus`
+**Model fit:** Low — pattern lookup critical first
+
+**Tests:**
+- Publishing a subscribed event type enqueues `WebhookDeliveryWorker`
+- Publishing an unrelated event type does not enqueue
+- Worker receives correct `delivery_id`
+
+**Acceptance criteria:**
+- Subscription registered in the correct initializer/subscriber location (match existing pattern exactly)
+- `WebhookDelivery` record created before enqueue (delivery ID must exist)
+- Subscriber looks up active `WebhookSubscription` records for event type
+
+**Files touched:** subscription registration location (TBD from codebase), `spec/` integration or subscriber spec
+
+> ⚠️ **Risk area:** Creating the `WebhookDelivery` record (with status `:pending`) before enqueue is implicit in this step — make it explicit in the test.
+
+---
+
+## Definition of Done
+
+Each step:
+- [ ] One failing test written first
+- [ ] Minimum code to pass
+- [ ] All prior tests still green
+- [ ] Committed with tagged message
+
+Full plan done when:
+- [ ] End-to-end: publish event → HTTP POST fires in integration test or manual smoke test
+- [ ] CLAUDE.md updated if any new commands added
+- [ ] README updated if observable behavior changed
+
+---
+
+## Rollback Approach
+
+EventBus subscription is the final integration point. Steps 1–4 are safe to merge independently — no live behavior until Step 5 wires the subscription. If Step 5 is problematic, revert the subscription registration only; service and worker remain.
+
+---
+
+## CHECK Criteria
+
+After all steps: run full test suite, verify no regressions, confirm `WebhookDelivery` records are created with correct status transitions in a local smoke test.
+
+## ACT (post-implementation)
+
+5–10 min retrospective: Did any step split unexpectedly? Was the 4xx vs 5xx retry boundary clear enough? Propose working agreement update if the \"re-raise for retry / return for non-retry\" convention should be documented.
+
+---
+
+> **To execute each step, invoke PDCA Do. Do not begin any step without first opening that prompt.**
+```
+
+### 1b-needs-refactoring (Planning)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'refactor'` — 'refactor' found in output
+- ✅ `must_contain: 'feat'` — 'feat' found in output
+- ✅ `must_not_contain: 'Here is the complete implementation'` — 'Here is the complete implementation' absent (good) in output
+- ✅ `must_not_contain: 'skip the refactor'` — 'skip the refactor' absent (good) in output
+
+**Judge reasoning:**
+
+> The Actual Output demonstrates strong alignment with all four evaluation steps. Step 1: Contains 11 numbered atomic steps (refactor steps 1-4, feature steps 5-9, completion steps 10-11), each describing exactly one testable behavior change, sequenced logically from audit → extraction → scoping → documentation, with clear independence. Step 2: Includes a comprehensive Test List as a distinct planning artifact enumerated during planning (not execution), covering golden path cases (valid payments, report generation), degenerate cases (empty data, invalid date ranges), and exception scenarios (gateway timeouts, cross-tenant access, missing context). Step 3: All refactoring work explicitly tagged with 'refactor:' prefix (steps 1-4) and positioned before 'feat:' steps (5-9); each refactor step includes explicit statements that 'all existing tests pass' or 'no new logic introduced'; no refactoring omitted. Step 4: No copy-paste-ready implementation code present; method names (PaymentProcessor, ReportingService), schema references (TenantContext), and ASCII structural diagrams are provided as contextual references; each step includes clear acceptance criteria and definition of done (e.g., 'git diff shows only moves + delegation', 'line count confirmed', 'no cross-tenant data leakage in tests'). Strengths include explicit gating checks (e.g., 'human reviews map before proceeding'), risk mitigation table, and rollback strategy. Minor: Step 11 (Retrospective) is labeled 'ACT' rather than 'feat:' or 'refactor:', but this is a distinct completion category appropriately sequenced after implementation.
+
+**Input:**
+
+```
+Analysis complete. Adding multi-tenant support to our billing module. Problem: BillingService is a 600-line God object mixing tenant logic, payment processing, and reporting. We need to extract PaymentProcessor and ReportingService before adding tenant scoping. Approach chosen: extract-then-scope pattern.
+```
+
+**Model output:**
+
+```
+# Planning Phase: BillingService Decomposition + Multi-Tenant Scoping
+
+## Integration Strategy
+
+### End-to-End Data Flow
+```
+Tenant Request → TenantContext (scoping) → PaymentProcessor (payment logic)
+                                         → ReportingService (reporting logic)
+                                         ↑
+                              BillingService (orchestrator, reduced)
+```
+
+### Touch Points
+- `BillingService` — will become a thin orchestrator; existing method signatures preserved for backward compatibility
+- `PaymentProcessor` — extracted class; owns payment state and side effects
+- `ReportingService` — extracted class; owns report generation and aggregation
+- `TenantContext` — new scoping primitive injected at orchestrator boundary
+- Callers of `BillingService` — must remain unaware of internal restructuring until tenant scoping is explicitly exposed
+
+### Backward Compatibility
+- Phase 1 (refactor steps): All existing public method signatures on `BillingService` unchanged, all existing tests pass
+- Phase 2 (feat steps): New tenant-scoped entry points added; old entry points deprecated but not removed
+
+---
+
+## Test List (Planning Artifact)
+
+### PaymentProcessor behaviors
+- Processes a valid payment and returns success result
+- Rejects payment with missing required fields
+- Handles payment gateway timeout gracefully
+- Handles payment gateway failure (non-timeout)
+- Does not mutate state on failed payment
+- Idempotency: duplicate payment request returns same result without double-charge
+
+### ReportingService behaviors
+- Generates report for date range with data present
+- Generates report for date range with no data (empty/zero state)
+- Aggregates correctly across multiple records
+- Handles report request with invalid date range
+
+### TenantContext / tenant scoping behaviors
+- Payment scoped to tenant A is invisible to tenant B
+- Report scoped to tenant A returns only tenant A data
+- Missing/invalid tenant context is rejected at boundary (not silently ignored)
+- Tenant context propagates correctly through orchestrator to both extracted services
+
+### BillingService (orchestrator) behaviors
+- Delegates payment requests to PaymentProcessor
+- Delegates report requests to ReportingService
+- Existing callers receive same results after refactor (regression)
+
+---
+
+## Implementation Plan
+
+### Preparatory Refactoring Steps
+*(These steps must leave all existing tests green — zero behavioral change)*
+
+**Step 1 — `refactor:` Audit and document BillingService boundaries**
+- Read all 600 lines; annotate which methods/blocks belong to: payment, reporting, orchestration
+- Produce a written method map (comment block or markdown scratch file)
+- Acceptance: clear ownership assigned to every method; no code changed
+- CHECK: human reviews map before proceeding
+
+**Step 2 — `refactor:` Extract PaymentProcessor class (no logic change)**
+- Move payment methods verbatim into `PaymentProcessor`
+- `BillingService` delegates to `PaymentProcessor` instance
+- Acceptance: all existing tests pass; no new logic introduced
+- CHECK: `git diff` shows only moves + delegation; test suite green
+
+**Step 3 — `refactor:` Extract ReportingService class (no logic change)**
+- Move reporting methods verbatim into `ReportingService`
+- `BillingService` delegates to `ReportingService` instance
+- Acceptance: all existing tests pass; no new logic introduced
+- CHECK: `git diff` shows only moves + delegation; test suite green
+
+**Step 4 — `refactor:` Slim BillingService to pure orchestrator**
+- Remove any residual mixed logic; confirm BillingService only coordinates
+- Acceptance: `BillingService` under ~100 lines; all tests still green
+- CHECK: line count confirmed; no failing tests
+
+---
+
+### Feature Steps
+*(Each step: write one failing test → implement → test passes → commit)*
+
+**Step 5 — `feat:` TenantContext primitive**
+- Implement `TenantContext` value object (tenant ID, validation, equality)
+- Test: valid context constructed; invalid/missing tenant ID raises at construction
+- Acceptance: unit tests pass; no integration with BillingService yet
+- CHECK: tests green; value object is immutable
+
+**Step 6 — `feat:` Tenant scoping on PaymentProcessor**
+- `PaymentProcessor` accepts `TenantContext`; queries/writes scoped to tenant
+- Tests: payment for tenant A not visible to tenant B; missing context rejected
+- Acceptance: new scoping tests pass; existing PaymentProcessor tests still pass
+- CHECK: no cross-tenant data leakage in tests
+
+**Step 7 — `feat:` Tenant scoping on ReportingService**
+- `ReportingService` accepts `TenantContext`; report data scoped to tenant
+- Tests: report for tenant A returns only tenant A data; missing context rejected
+- Acceptance: new scoping tests pass; existing ReportingService tests still pass
+- CHECK: no cross-tenant data leakage in tests
+
+**Step 8 — `feat:` BillingService propagates TenantContext**
+- Orchestrator accepts `TenantContext` and passes through to both services
+- Tests: context propagates correctly; orchestrator rejects missing context
+- Acceptance: integration-level regression tests pass; existing callers unaffected
+- CHECK: end-to-end test covering full flow for two isolated tenants
+
+**Step 9 — `feat:` Deprecate un-scoped entry points**
+- Add deprecation notices (warnings/annotations) to old entry points
+- Acceptance: deprecated markers present; no runtime behavior change; no test failures
+- CHECK: human confirms deprecation strategy matches project conventions
+
+---
+
+### Mandatory Completion Steps
+
+**Step 10 — Documentation**
+- Update README: document `PaymentProcessor`, `ReportingService`, `TenantContext` and their responsibilities
+- Update CLAUDE.md: add any new build commands, test commands, or architectural notes
+- Acceptance: both files updated; no orphaned references to old monolithic BillingService
+- CHECK: human reviews docs for accuracy
+
+**Step 11 — ACT: Retrospective**
+- 5–10 min review: What slowed us down? What assumptions were wrong? Any working agreement updates?
+- Proposed candidates: anything discovered during Step 1 audit; any patterns that should be codified
+
+---
+
+## Risk Areas
+
+| Risk | Mitigation |
+|---|---|
+| Hidden coupling discovered during extraction | Step 1 audit is a hard gate; no extraction until map is reviewed |
+| Existing tests testing internal implementation details | Flag during Step 2/3; refactor tests to test behavior, not structure |
+| Tenant context leakage via shared mutable state | Immutability enforced at Step 5; checked explicitly in Steps 6–8 |
+| Callers passing no tenant context (runtime) | Boundary rejection at orchestrator (Step 8) not buried in services |
+
+## Rollback Approach
+
+Each refactor step is an independent commit. If extraction introduces a regression, `git revert` to the prior green commit. Feature steps are additive; rollback is removal of new entry points without touching refactored structure.
+
+---
+
+> **To execute each step, invoke PDCA Do. Do not begin any step without first opening that prompt.**
+```
+
+### 1b-multi-system (Planning)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'Node'` — 'Node' found in output
+- ✅ `must_contain: 'Python'` — 'Python' found in output
+- ✅ `must_not_contain: 'Here is the code'` — 'Here is the code' absent (good) in output
+- ✅ `must_not_contain: 'npm install'` — 'npm install' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong alignment with all five key PDCA Planning Phase requirements. (1) Structural compliance is excellent: nine numbered atomic steps (0–9) each describing one testable behavior change, an enumerated test list covering golden path (metrics written, cached, served), degenerate cases (empty cache, stale data), and exception handling (Redis unavailable, reconnection), with explicit refactor: tagging in Step 0 and feat: tags on all subsequent implementation steps. (2) Content compliance is very solid: step descriptions reference method names (write_metric, XADD, metricsCache.set/get, XREAD), schema details (stream key `metrics:usage`, 30s TTL), and ASCII diagrams (data flow diagram), used only as context—no runnable code or migration DSL is present. Each step includes clear acceptance criteria and definition of done. (3) No runnable Python or JavaScript code is present; tasks are described at the specification level. (4) The response includes a comprehensive test strategy enumerated upfront (tests 1–8 covering Python and Node.js), and explicitly addresses refactoring prerequisites in Step 0 with conditional logic. (5) Documentation and CHECK/ACT steps are included, addressing backward compatibility and retrospective closure. Minor gap: Step 9 (docs) uses checkbox notation rather than being fully integrated into the numbered step sequence, and the conditional refactor in Step 0 could specify slightly more explicit confirmation language for 'no refactoring needed' scenarios, but this is a minor structural nuance that does not impair compliance.
+
+**Input:**
+
+```
+Analysis complete. We need to add real-time usage metrics that flow from our Python data pipeline into our Node.js API for display. Integration point: shared Redis stream. Chosen approach: Python writes metrics events to Redis stream, Node.js consumer reads and caches in memory with 30s TTL.
+```
+
+**Model output:**
+
+```
+# Planning Phase: Real-Time Usage Metrics via Redis Stream
+
+## Integration Strategy
+
+### End-to-End Data Flow
+
+```
+Python Pipeline → Redis Stream → Node.js Consumer → In-Memory Cache (30s TTL) → API Endpoint → Client
+```
+
+**Touch Points:**
+1. **Python side**: New metrics writer module that publishes events to Redis stream (`XADD`)
+2. **Redis**: Stream key (e.g., `metrics:usage`), no consumer groups needed for single consumer
+3. **Node.js side**: Stream consumer loop (`XREAD`), in-memory cache layer, new API route
+
+### Required Changes to Existing Methods/Interfaces
+- Python: Minimal — new module, hooked into existing pipeline emit/flush points
+- Node.js: New service + route; existing route registration pattern followed
+- No existing interfaces broken; additive only
+
+### Backward Compatibility
+- Python pipeline continues functioning if Redis is unavailable (metrics writes are fire-and-forget)
+- Node.js API returns empty/stale metrics gracefully if consumer hasn't started or Redis is down
+
+---
+
+## Testing Strategy
+
+**Behavioral test list (enumerate all before executing one at a time):**
+
+### Python
+1. Metrics event is serialized and written to Redis stream with correct fields
+2. Writer fails silently (logs, does not raise) when Redis is unreachable
+3. Multiple pipeline events produce multiple stream entries in order
+
+### Node.js
+4. Consumer reads new entries from stream and populates cache
+5. Cached metrics are served via API endpoint
+6. Stale cache (>30s) returns empty/default rather than stale data
+7. API returns 200 with empty payload when no metrics received yet
+8. Consumer recovers and resumes reading after Redis reconnection
+
+---
+
+## Preparatory Refactoring
+
+- [ ] Confirm Python pipeline has an observable emit point (hook location) — no refactor needed if it does, extract one if not
+- [ ] Confirm Node.js app has a service initialization sequence where a long-running consumer can be started cleanly — if ad-hoc, extract a `startServices()` bootstrap step first
+
+If both exist as-is: **structure is ready, no preparatory refactoring needed.** Verify this in Step 0.
+
+---
+
+## Implementation Plan
+
+### Step 0 — `refactor:` (conditional) — Verify hook points exist
+**Task:** Inspect Python pipeline for emit hook; inspect Node.js for service bootstrap  
+**Acceptance criteria:** Both hook points identified and documented (file + line); refactor only if missing  
+**Definition of done:** Existing tests still pass; no behavioral change
+
+---
+
+### Step 1 — `feat:` Python — Redis stream writer module
+**Task:** Create `metrics_writer.py` (or equivalent per project naming) with a `write_metric(event: dict)` function that calls `XADD metrics:usage * field value ...`  
+**Test (write first):** Unit test — mock Redis client, assert `XADD` called with correct stream key and serialized fields  
+**Acceptance criteria:** Single function, dependency-injected Redis client, no side effects on import  
+**Definition of done:** Test passes; function does one thing
+
+---
+
+### Step 2 — `feat:` Python — Silent failure on Redis unavailable
+**Task:** Wrap `XADD` call in try/except; log error, do not raise  
+**Test (write first):** Unit test — Redis client raises `ConnectionError`; assert no exception propagates; assert log call made  
+**Acceptance criteria:** Pipeline continues uninterrupted when Redis is down  
+**Definition of done:** Test passes
+
+---
+
+### Step 3 — `feat:` Python — Hook writer into pipeline
+**Task:** Call `write_metric()` at the identified emit point in the pipeline  
+**Test (write first):** Integration test — run pipeline with mock Redis; assert stream entries produced for each pipeline event  
+**Acceptance criteria:** Each pipeline event produces one stream entry; order preserved  
+**Definition of done:** Test passes; existing pipeline tests still pass
+
+---
+
+### Step 4 — `feat:` Node.js — In-memory cache module
+**Task:** Create `metricsCache.js` (or `.ts`) with `set(data)`, `get()`, `isStale()` — 30s TTL enforced on `get()`  
+**Test (write first):** Unit tests — `get()` returns data within TTL; `get()` returns `null` after 30s; `set()` resets TTL  
+**Acceptance criteria:** No Redis dependency in this module; pure in-memory  
+**Definition of done:** All three behavioral tests pass
+
+---
+
+### Step 5 — `feat:` Node.js — Redis stream consumer service
+**Task:** Create `metricsConsumer.js` — `start()` function that loops `XREAD` (blocking or polling), parses entries, calls `metricsCache.set()`  
+**Test (write first):** Unit test — mock Redis `XREAD` returning entries; assert `metricsCache.set()` called with parsed data  
+**Acceptance criteria:** Tracks last-read stream ID (`$` on first start, then last seen ID); handles empty reads gracefully  
+**Definition of done:** Test passes; consumer does not crash on empty stream
+
+---
+
+### Step 6 — `feat:` Node.js — Consumer recovery on Redis disconnect
+**Task:** Wrap `XREAD` loop in try/catch; on error, wait (e.g., 5s backoff) and retry  
+**Test (write first):** Unit test — mock Redis throws on first call, succeeds on second; assert consumer continues and eventually calls `set()`  
+**Acceptance criteria:** Consumer does not exit process; resumes reading after reconnection  
+**Definition of done:** Test passes
+
+---
+
+### Step 7 — `feat:` Node.js — API endpoint for metrics
+**Task:** Add `GET /metrics/usage` route; handler calls `metricsCache.get()`, returns data or `{}` with 200  
+**Test (write first):** Integration/route test — cache populated → returns data; cache empty → returns `{}`; cache stale → returns `{}`  
+**Acceptance criteria:** Always 200; never 500 due to missing data; correct Content-Type  
+**Definition of done:** All three route test cases pass
+
+---
+
+### Step 8 — `feat:` Node.js — Wire consumer into service bootstrap
+**Task:** Call `metricsConsumer.start()` in the app's service initialization sequence  
+**Test (write first):** Integration test — app starts; consumer is running (spy or observable side effect)  
+**Acceptance criteria:** Consumer starts exactly once on app boot; does not block startup  
+**Definition of done:** Test passes; app boots cleanly
+
+---
+
+### Step 9 — `docs:` — Update build and documentation
+**Task (explicit — not implied):**
+- [ ] Add any new env vars (`REDIS_URL`, stream key name) to `.env.example` and README
+- [ ] Update `CLAUDE.md` commands table if new scripts added
+- [ ] Document the metrics stream contract (key name, field names, entry format) in a short ADR or inline README section
+**Acceptance criteria:** A new developer can understand the integration from docs alone  
+**Definition of done:** README and CLAUDE.md reviewed and updated
+
+---
+
+## CHECK Step
+Verify against:
+- All 8 behavioral tests from the test list pass (Python: 1–3, Node.js: 4–8)
+- No existing tests broken
+- Silent failure confirmed via manual Redis kill test
+- API returns 200 in all cache states (populated, empty, stale)
+- Docs updated (env vars, CLAUDE.md, stream contract)
+
+## ACT Step
+- 5–10 min retrospective after implementation
+- Note: Did the 30s TTL cause any test timing issues? (if yes: add to working agreements — always inject clock/time in cache modules)
+- Note: Was the Redis stream ID tracking (last-seen ID) harder than expected? (if yes: consider extracting to its own tested module next time)
+- Propose any working agreement updates based on friction encountered
+
+---
+
+> **To execute each step, invoke the PDCA Do prompt. Do not begin any step without first opening that prompt.**
+```
+
+### 2-first-step (TDD Implementation)
+
+**GEval:** 0.70 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'all done'` — 'all done' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong TDD discipline with clear architectural safety checks and a well-structured full test list upfront. All four called shots are present and clearly labeled with Test name, Behavior under test, Expected failure, and Why this test first. The first test correctly targets a degenerate case (nil event_type), and the stub phase correctly identifies that a no-op class would not satisfy the test. The RED→GREEN cycle for tests 1 and 2 is properly executed with appropriate validation logic added only as needed. Test 3 correctly validates the payload type with a custom validator that avoids premature conditional branching. However, the response is incomplete—Test 4 (happy path) is initiated with a called shot but cuts off mid-implementation before reaching the GREEN phase or the required 'Implementation finished, moving to CHECK phase' handoff statement. This truncation violates the requirement to confirm the work is not declared finished and properly hand off with explicit language.
+
+**Input:**
+
+```
+Rails 7 app, PostgreSQL, RSpec + FactoryBot. Adding webhook support. Step 1: Implement WebhookDelivery — accepts event_type (string) and payload (hash), persists to database. File locations confirmed: app/models/webhook_delivery.rb (new), db/migrate/TIMESTAMP_create_webhook_deliveries.rb (new), spec/models/webhook_delivery_spec.rb (new). No existing WebhookDelivery files. ApplicationRecord base class. Start TDD now.
+```
+
+**Model output:**
+
+```
+I'll check the baseline before writing any code.
+
+```bash
+# Confirm no existing WebhookDelivery files
+find . -name \"*webhook*\" -o -name \"*Webhook*\" 2>/dev/null | grep -v \".git\"
+```
+
+Assuming clean baseline (no existing webhook files). Let me begin.
+
+---
+
+## Architectural Safety Check
+
+- **New files:** `app/models/webhook_delivery.rb`, `spec/models/webhook_delivery_spec.rb`, migration — all fit Rails conventions ✅
+- **ApplicationRecord** already exists, we inherit from it ✅
+- **No existing usages** to break ✅
+
+File locations confirmed:
+- `app/models/webhook_delivery.rb` (new)
+- `db/migrate/TIMESTAMP_create_webhook_deliveries.rb` (new)
+- `spec/models/webhook_delivery_spec.rb` (new)
+
+---
+
+## Full Test List (before writing any code)
+
+Working out all cases upfront:
+
+1. **Degenerate:** invalid without `event_type` (nil)
+2. **Exception:** invalid without `payload` (nil)
+3. **Exception:** invalid when `event_type` is blank string
+4. **Exception:** `payload` must be a hash (rejects non-hash)
+5. **Happy path:** valid record with `event_type` string + `payload` hash persists
+6. **Happy path:** persisted record round-trips `payload` hash correctly from DB
+
+---
+
+## 🚨 CALLED SHOT — Test 1
+
+- **Test name:** `is invalid without event_type`
+- **Behavior under test:** `WebhookDelivery` with `event_type: nil` fails validation
+- **Expected failure:** `undefined method 'valid?' for nil` OR more precisely — `NameError: uninitialized constant WebhookDelivery` because the class doesn't exist yet
+- **Why this test first:** Degenerate/zero case establishes the API (class exists, has `event_type` attribute, validates presence) before any logic
+- **Stub check:** A no-op stub (`class WebhookDelivery < ApplicationRecord; end`) would *not* satisfy this test — Rails default behavior without `validates :event_type, presence: true` would make the record *valid* with nil (no validation fires), so this test stays genuinely RED until the validation is added. ✅
+
+---
+
+### RED Phase — Test 1
+
+**`spec/models/webhook_delivery_spec.rb`**
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe WebhookDelivery, type: :model do
+  describe 'validations' do
+    it 'is invalid without event_type' do
+      delivery = WebhookDelivery.new(payload: { \"foo\" => \"bar\" })
+      expect(delivery).not_to be_valid
+      expect(delivery.errors[:event_type]).to include(\"can't be blank\")
+    end
+  end
+end
+```
+
+Run it — expected failure:
+
+```
+NameError: uninitialized constant WebhookDelivery
+```
+
+---
+
+### Stub (compile-but-fail stub) — Migration first
+
+**`db/migrate/TIMESTAMP_create_webhook_deliveries.rb`**
+
+```ruby
+class CreateWebhookDeliveries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :webhook_deliveries do |t|
+      t.string  :event_type, null: false
+      t.jsonb   :payload,    null: false, default: {}
+
+      t.timestamps
+    end
+  end
+end
+```
+
+```bash
+rails db:migrate
+rails db:migrate RAILS_ENV=test
+```
+
+**`app/models/webhook_delivery.rb`** — stub, compiles, no validations yet:
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+end
+```
+
+Run test now — expected behavioral failure:
+
+```
+expected #<WebhookDelivery id: nil, event_type: nil, payload: {}> not to be valid
+```
+
+That's our genuine RED (record is valid when it shouldn't be). ✅
+
+---
+
+### GREEN Phase — Test 1
+
+Add the presence validation:
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  validates :event_type, presence: true
+end
+```
+
+Run — GREEN ✅
+
+---
+
+## 🚨 CALLED SHOT — Test 2
+
+- **Test name:** `is invalid without payload`
+- **Behavior under test:** `WebhookDelivery` with `payload: nil` fails validation
+- **Expected failure:** `expected #<WebhookDelivery ...> not to be valid` (record is currently valid with nil payload — no validation exists yet)
+- **Why this test first:** Closes the second required field before moving to happy path
+- **Stub check:** Current model has no payload validation, so this will be RED ✅
+
+---
+
+### RED Phase — Test 2
+
+Add to the `'validations'` describe block:
+
+```ruby
+it 'is invalid without payload' do
+  delivery = WebhookDelivery.new(event_type: 'order.created', payload: nil)
+  expect(delivery).not_to be_valid
+  expect(delivery.errors[:payload]).to include(\"can't be blank\")
+end
+```
+
+Run — RED (nil payload passes with current stub) ✅
+
+---
+
+### GREEN Phase — Test 2
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  validates :event_type, presence: true
+  validates :payload,    presence: true
+end
+```
+
+Run both tests — GREEN ✅
+
+---
+
+## 🚨 CALLED SHOT — Test 3
+
+- **Test name:** `is invalid when event_type is blank`
+- **Behavior under test:** Empty string `\"\"` for `event_type` fails validation (presence: true covers this, but we verify explicitly)
+- **Expected failure:** This will actually be **GREEN immediately** — `presence: true` already rejects blank strings
+- **Decision:** Skip — vacuously green against current implementation. Rails `presence: true` handles blank. Move to next non-trivial test.
+
+---
+
+## 🚨 CALLED SHOT — Test 4 (promoted to Test 3)
+
+- **Test name:** `is invalid when payload is not a hash`
+- **Behavior under test:** `payload: \"a string\"` or `payload: [1,2,3]` fails validation — payload must be a Hash
+- **Expected failure:** `expected #<WebhookDelivery ...> not to be valid` — current model accepts any value for payload as long as it's present
+- **Why this test first:** Defines the type contract. A record with `payload: \"oops\"` currently passes, which is wrong.
+- **Stub check:** Current validation only checks presence, not type — genuinely RED ✅
+
+---
+
+### RED Phase — Test 3 (payload type)
+
+```ruby
+it 'is invalid when payload is not a hash' do
+  delivery = WebhookDelivery.new(event_type: 'order.created', payload: \"not a hash\")
+  expect(delivery).not_to be_valid
+  expect(delivery.errors[:payload]).to include(\"must be a Hash\")
+end
+```
+
+Run — RED (string payload currently passes presence check) ✅
+
+---
+
+### GREEN Phase — Test 3
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  validates :event_type, presence: true
+  validates :payload,    presence: true
+  validate  :payload_must_be_hash
+
+  private
+
+  def payload_must_be_hash
+    return if payload.nil? # presence validator handles nil
+    errors.add(:payload, 'must be a Hash') unless payload.is_a?(Hash)
+  end
+end
+```
+
+Run all three tests — GREEN ✅
+
+---
+
+## 🚨 CALLED SHOT — Test 4 (happy path — persists)
+
+- **Test name:** `is valid with event_type and a payload hash`
+- **Behavior under test:** A record with valid attributes saves to the database
+- **Expected failure:** Should be GREEN immediately — but this is the first test that calls `save` and exercises the actual DB round-trip, making it integration-meaningful
+- **Why this test:** Confirms the migration and model wire up correctly end-to-end. Can't be skipped.
+- **Stub check:** All three validations exist — this *should* pass. We run it to confirm the migration worked.
+
+```ruby
+it 'is valid with event_type and a payload hash' do
+  delivery = WebhookDelivery.new(
+    event_type:
+```
+
+### 2-skip-tests-request (TDD Implementation)
+
+**GEval:** n/a / threshold 0.00 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'class WebhookDelivery'` — 'class WebhookDelivery' absent (good) in output
+- ✅ `must_not_contain: 'def self.create'` — 'def self.create' absent (good) in output
+
+**Judge reasoning:**
+
+> GEval skipped for this scenario type
+
+**Input:**
+
+```
+Let's skip the tests for now and just write the WebhookDelivery implementation. We can add tests later — we're on a deadline.
+```
+
+**Model output:**
+
+```
+I need to stop here and be direct with you.
+
+**I can't skip the tests and \"add them later.\"**
+
+This isn't bureaucratic rule-following — it's that \"later\" reliably never comes, and more importantly, **the tests aren't the point. The design feedback is.**
+
+Here's what actually happens when we skip TDD under deadline pressure:
+
+1. **We write more code, not less.** Without tests forcing minimal implementations, the code grows to handle imagined scenarios. We'll write the wrong thing faster.
+
+2. **\"Add tests later\" means testing the implementation, not the behavior.** Tests written after the fact confirm what the code *does*, not what it *should do*. That's not a safety net — it's a transcript.
+
+3. **The deadline pressure doesn't go away.** It compounds. Untested code generates debugging time, which generates more deadline pressure.
+
+---
+
+**What I can do right now:**
+
+If the deadline is real, let's make TDD *faster*, not skip it:
+
+- **Scope reduction:** What's the smallest WebhookDelivery that solves the actual deadline problem? Let's cut scope, not quality gates.
+- **Degenerate case first takes 5 minutes.** The first test + stub is fast. It's the design conversation that saves time later.
+- **Timebox the red-green cycle:** 15 minutes per behavior. If a test takes longer, the design is wrong — that's valuable information you'd otherwise discover in production.
+
+---
+
+**What's the actual deadline constraint?**
+
+Tell me what WebhookDelivery *must* do by when, and I'll help you find the minimum viable implementation — tested, working, and shippable. That's faster than the alternative.
+```
+
+### 2-beads-ordering-capture (TDD Implementation)
+
+**GEval:** 0.80 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'bd update'` — 'bd update' found in output
+- ✅ `must_contain: '--append-notes'` — '--append-notes' found in output
+- ✅ `must_contain: 'TDD ordering:'` — 'TDD ordering:' found in output
+- ✅ `must_contain: 'Reason:'` — 'Reason:' found in output
+- ✅ `must_not_contain: 'all done'` — 'all done' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong alignment with TDD discipline and the evaluation steps. Strengths: (1) A complete called shot is present with all four required fields—Test name, Behavior under test, Expected failure, and Why this test first—clearly articulated. (2) The first test correctly targets a degenerate/conditional case (confidence < 0.7 → escalate=True) rather than the happy path, explicitly explaining why this ordering prevents vacuous greens. (3) The stub analysis correctly identifies that the current stub (empty dict) will fail the test, confirming genuine RED phase alignment. (4) The response appropriately halts before implementation, requesting file location confirmation rather than proceeding unilaterally. Weaknesses: (1) The response does not include an explicit handoff statement equivalent to 'Implementation finished, moving to CHECK phase'—instead it ends with a request for confirmation, which is contextually appropriate but deviates slightly from the expected closure format. (2) The beads tracking update uses a narrative explanation rather than strict TDD language, though it is functionally sound. The response correctly avoids writing production code or tests prematurely, respects stub discipline, and articulates why test ordering matters for conditional logic. The only gap is the missing explicit phase-completion signaling language.
+
+**Input:**
+
+```
+Python agent framework. Starting DO phase step: implement draft_step(context) -> StepOutput. Spec: (A) content[\"draft_response\"] is always a non-empty string, (B) when context.confidence < 0.7, content[\"escalate\"] = True, (C) when context.confidence >= 0.7, escalate key is absent. Beads issue: pdca-abc (status: in_progress, assigned to you). Current stub: def draft_step(context): return StepOutput(content={}). No tests yet. Set up the beads task tracking for this TDD step, then identify the first test to write.
+```
+
+**Model output:**
+
+```
+I'll start with the beads task tracking, then apply the mandatory pre-test analysis.
+
+## Beads Task Tracking
+
+```bash
+bd update pdca-abc --append-notes \"$(cat <<'EOF'
+TDD ordering: [escalate flag test] before [happy-path draft_response test]
+Reason: happy-path first risks implementing full conditional in one GREEN step,
+making conditional-branch tests (confidence < 0.7 → escalate=True,
+confidence >= 0.7 → escalate absent) vacuously green before they are written.
+
+Test sequence planned:
+1. confidence < 0.7 → content[\"escalate\"] == True (conditional branch)
+2. confidence >= 0.7 → \"escalate\" not in content (conditional branch, other side)
+3. draft_response is non-empty string (happy path / spec A)
+4. draft_response present even when escalating (combined case)
+EOF
+)\"
+```
+
+---
+
+## Architectural Safety Check
+
+Before writing any code:
+
+```bash
+# Check existing structure
+Glob **/*step* **/*output* **/*context*
+Grep draft_step
+Grep StepOutput
+Grep AgentContext  # or whatever Context type is
+```
+
+**Awaiting your confirmation of file locations before I touch anything.** Please share the glob/grep output, or tell me the relevant files.
+
+---
+
+## 🚨 CALLED SHOT — First Test
+
+**Test name:** `test_draft_step_sets_escalate_true_when_confidence_below_threshold`
+
+**Behavior under test:** When `context.confidence < 0.7`, `content[\"escalate\"]` is `True`
+
+**Expected failure:**
+```
+KeyError: 'escalate'
+# or
+AssertionError: assert 'escalate' in {}
+```
+The current stub returns `StepOutput(content={})`, so `content[\"escalate\"]` will raise `KeyError` or an `in` check will fail.
+
+**Why this test first:** The spec has a conditional branch (`confidence < 0.7`). If I write the happy-path (`draft_response` is non-empty) first, I could satisfy it with a no-op stub that returns a hardcoded string — no conditional needed. That makes the escalate-branch tests vacuously green once I add the conditional later. The escalate tests *force* the conditional to be written explicitly, in a controlled step.
+
+**Stub check:** Could a no-op stub satisfy this test? No — `content={}` fails immediately. ✅ This is the genuine RED.
+
+---
+
+## Next: Confirm File Locations
+
+Before I write the test or touch any file, please share:
+
+1. Output of `Glob **/*step*.py **/*output*.py **/*context*.py` (or equivalent)
+2. Where tests currently live (e.g., `tests/`, `test_*.py` pattern)
+3. Which existing test file is the best home for this — I want to add to an existing fixture rather than create a new file if `step`-related tests already exist
+
+Once confirmed, I'll write the RED test only — no production code yet.
+```
+
+### 2-after-passing-test (TDD Implementation)
+
+**GEval:** retried — 3/3 shots passed ✅
+
+**Mechanical:** 2/3 shots passed
+
+**Shot 1:** GEval 0.90 ✅ | Mechanical ❌
+> The response demonstrates exceptional TDD discipline across all evaluation steps. Step 1 (Process Police): not applicable, input doesn't ask to skip tests. Step 2 (Called Shot Discipline): All four fields are present and filled for both identified tests—test names, behaviors under test, expected failures, and reasoning for test order are explicit and clear. Step 3 (Degenerate/Zero Case First): The response correctly identifies that the current stub already satisfies tests #2 and #3 vacuously (nil payload, empty string event_type return nil because the stub returns nil for everything), and appropriately calls out this anti-pattern. It correctly pivots to test #4 as the first genuine RED that the stub cannot satisfy. Step 4 (Stub Discipline and GREEN Over-Implementation): The initial stub is confirmed as a pure no-op returning only `nil` with no branching. The proposed GREEN phase implementation adds only the minimal guard clause for `nil event_type` (already passing) and the happy path persistence logic—no over-implementation. The response explicitly acknowledges that tests #2 and #3 should be written *after* #4 is green, preventing vacuous passes. Step 5 (Handoff Language): The response ends with a request for confirmation ('Confirm before proceeding: Run the new test...'), explicitly avoiding a claim that implementation is finished and maintaining TDD sequence discipline. The analysis is technically sound, pedagogically clear, and demonstrates deep understanding of TDD anti-patterns like vacuous test passes and test ordering.
+
+<details><summary>Shot 1 output</summary>
+
+```
+## Baseline Check
+
+Before writing anything new, let me confirm the current state matches what you've described.
+
+**Current state:**
+- Stub returns `nil` unconditionally ✅
+- Test #1 passing (nil event_type → nil) ✅
+- No conditional logic in stub ✅
+
+---
+
+## Next Test: #2 — nil payload
+
+**🚨 CALLED SHOT**
+
+- **Test name:** `returns nil when payload is nil`
+- **Behavior under test:** `WebhookDelivery.create(event_type: \"order.created\", payload: nil)` returns `nil`
+- **Expected failure:** This test will pass **immediately** against the current stub (which returns `nil` unconditionally)
+- **Stub check:** ✅ YES — the no-op stub satisfies this. So does test #3 (empty string event_type). The stub satisfies ALL nil/guard cases because it returns `nil` for everything.
+
+**This means tests #2 and #3 are vacuously green right now. Writing them would not give us a genuine RED.**
+
+---
+
+## Jump to the First Test the Stub Cannot Satisfy: #4
+
+The stub returns `nil` always. Test #4 (persist a valid record) expects a non-nil result — **the stub cannot satisfy this.**
+
+**🚨 CALLED SHOT — Test #4**
+
+- **Test name:** `persists a record with valid event_type and payload`
+- **Behavior under test:** `WebhookDelivery.create(event_type: \"order.created\", payload: { \"amount\" => 100 })` returns a persisted `WebhookDelivery` record (non-nil, `persisted?` is true)
+- **Expected failure:** `expected #<WebhookDelivery ...>.persisted? to be truthy, got false` — or more likely `expected nil to respond to persisted?`, since the stub returns `nil`
+- **Why this test first (among remaining):** This is the first test the stub *cannot* satisfy. Writing guard-clause tests (#2, #3) now would be vacuously green — they'd pass for the wrong reason (stub returns nil for everything, not because we checked the argument).
+- **Stub check:** The current stub returns `nil` always. This test expects a persisted record. Stub cannot satisfy it. ✅ Genuine RED.
+
+---
+
+## RED Phase
+
+Add this to `spec/models/webhook_delivery_spec.rb`:
+
+```ruby
+describe \".create\" do
+  # ... existing nil event_type test ...
+
+  it \"persists a record with valid event_type and payload\" do
+    result = WebhookDelivery.create(
+      event_type: \"order.created\",
+      payload: { \"amount\" => 100 }
+    )
+
+    expect(result).not_to be_nil
+    expect(result).to be_persisted
+    expect(result.event_type).to eq(\"order.created\")
+  end
+end
+```
+
+**Run it. Confirm the failure is:** something like `NoMethodError: undefined method 'persisted?' for nil` or `expected nil not to be nil` — i.e., the stub returning `nil` is the cause.
+
+If the failure matches → proceed to GREEN.
+
+---
+
+## GREEN Phase
+
+Minimal implementation — make the happy path work, keep the guard for `nil event_type`:
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  def self.create(event_type:, payload:)
+    return nil if event_type.nil?
+
+    record = new(event_type: event_type, payload: payload)
+    record.save
+    record
+  end
+end
+```
+
+**Run all tests. Confirm:**
+- Test #1 (nil event_type → nil) ✅ still green
+- Test #4 (persist valid record) ✅ now green
+
+---
+
+## Then: Write #2 and #3 as Genuine Tests
+
+Once #4 is green and committed, tests #2 and #3 become meaningful — they verify that the guard clauses you just added work correctly for `nil payload` and `\"\"` event_type. Write them, watch them **fail** (because the current implementation doesn't guard those yet), then add the guards.
+
+**Commit message for this step:**
+
+```
+RED→GREEN: WebhookDelivery.create persists valid record
+
+Test #4 from list. Stub cannot satisfy non-nil persisted result.
+Guards: nil event_type returns nil (existing).
+Next: add guards for nil payload and empty string event_type.
+```
+
+---
+
+**⚠️ Confirm before proceeding:** Run the new test against the current stub first. Post the actual failure message so we can verify it matches the predicted failure before writing any production code.
+```
+
+</details>
+**Shot 2:** GEval 0.90 ✅ | Mechanical ✅
+> The response demonstrates strong TDD discipline and correctly applies the PDCA DO phase. It properly identifies that tests (2) and (3) would pass vacuously against the current stub, then executes a 'called shot' for test (4) with all four required fields: test name, behavior under test, expected failure message (\"expected WebhookDelivery.count to change by 1 but was not changed\"), and clear reasoning for why this test should run first. The called shot correctly targets a non-degenerate case (persisting a record), but the response justifies this by explaining the stub cannot satisfy it. The GREEN phase implementation uses delegation to `super` which is appropriately minimal and avoids over-implementation. The response correctly identifies that adding guards would over-implement beyond test (4)'s requirements and defers them to the next cycle. The output concludes with a clear handoff statement ('Next sequence') indicating work on this test cycle is complete, and follows proper commit discipline. Minor weakness: the response doesn't explicitly confirm the stub returns only hardcoded values in its analysis, though the stub itself clearly does. The logic flow and TDD rigor are sound throughout.
+
+<details><summary>Shot 2 output</summary>
+
+```
+## Pre-Flight Check
+
+Before writing any new test, let me confirm the baseline.
+
+> **Tool check:** I'll use the current file state you've described rather than a diff command, since we're in a chat context. Baseline confirmed: stub returns `nil` for everything, one passing test.
+
+---
+
+## 🚨 CALLED SHOT — Test #2
+
+**Test name:** `create returns nil when payload is nil`
+
+**Behavior under test:** The method rejects `nil` payload and returns `nil` (mirrors the nil event_type guard)
+
+**Expected failure:**
+```
+expected: nil
+     got: nil
+```
+Wait — the current stub *always* returns `nil`. That means this test will pass **vacuously**. The stub already satisfies it without any behavioral implementation.
+
+**Stub check:** ✅ Yes — a no-op stub satisfies tests (2) and (3). I need to find the first test the stub *cannot* satisfy.
+
+That test is **(4): persists record with valid event_type and payload.**
+
+---
+
+## 🚨 REVISED CALLED SHOT — Jumping to Test #4
+
+Per the sequencing rule: *\"If the next test in sequence would pass trivially against the current stub, skip to the first test the stub cannot satisfy.\"*
+
+**Test name:** `create persists a record with valid event_type and payload`
+
+**Behavior under test:** Calling `WebhookDelivery.create(event_type: \"order.placed\", payload: { id: 1 })` inserts one row into the database
+
+**Expected failure:**
+```
+expected WebhookDelivery.count to change by 1
+     but was not changed
+```
+The stub returns `nil` and touches no database, so `count` stays flat. This is a genuine RED.
+
+**Why this test first:** Tests (2) and (3) are vacuously green against the current stub — the stub already returns `nil` for *all* inputs. Test (4) is the first test the stub *cannot* satisfy without real behavior. Writing it now forces real implementation.
+
+**Stub check:** A no-op stub cannot satisfy this test. ✅ Correct RED target.
+
+---
+
+## RED Phase — Write the Failing Test
+
+Add to `spec/models/webhook_delivery_spec.rb`:
+
+```ruby
+it \"persists a record with valid event_type and payload\" do
+  expect {
+    WebhookDelivery.create(event_type: \"order.placed\", payload: { id: 1 })
+  }.to change(WebhookDelivery, :count).by(1)
+end
+```
+
+Run it. Confirm the failure:
+
+```
+expected WebhookDelivery.count to change by 1
+     but was not changed
+```
+
+If the failure message is *different* from this — **STOP and diagnose before writing production code.**
+
+---
+
+## GREEN Phase — Minimal Implementation
+
+Once RED is confirmed, the minimal change is to delegate to `ActiveRecord::Base.create` and drop the hardcoded `nil` return. But the stub is overriding `create` — remove the override:
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  def self.create(event_type:, payload:)
+    super(event_type: event_type, payload: payload)
+  end
+end
+```
+
+> **Note:** This will turn tests (2) and (3) RED — the stub that made them vacuously green is now replaced with real behavior. That's exactly what we want. Those tests now earn their keep.
+
+Run the full suite. Expected state:
+- Test (1) — nil event\\_type → **still passes** only if you add a guard; without one it will now **fail** (AR will attempt to insert)
+- Test (2) — nil payload → **fails** (no guard yet)
+- Test (3) — empty string event\\_type → **fails** (no guard yet)  
+- Test (4) — persists record → **passes** ✅
+
+---
+
+## What This Reveals
+
+The guard logic for nil/empty inputs doesn't exist yet — tests (1), (2), (3) will flip RED with real AR behavior. That's correct: the stub was hiding that the guards weren't implemented.
+
+**Next sequence:**
+
+1. Confirm test (4) is GREEN
+2. Commit: `\"GREEN: persists record with valid event_type and payload\"`
+3. Return to test (1) — re-examine its failure message with real AR behavior
+4. Add guard: `return nil if event_type.nil? || payload.nil? || event_type.empty?`
+5. Run all tests — (1)(2)(3)(4) all GREEN
+6. Commit, then write test (5) for JSON storage
+
+---
+
+**⚠️ Process check:** Don't add the guard until test (4) is GREEN and committed. One thing at a time.
+```
+
+</details>
+**Shot 3:** GEval 0.80 ✅ | Mechanical ✅
+> The response demonstrates strong TDD discipline and called shot compliance. All four required fields are present and clearly labeled (Test name, Behavior under test, Expected failure, Why this test first). The sequencing decision to skip tests (2) and (3) as vacuous against the current stub and jump to test (4) as the first test the stub cannot satisfy is correct and well-reasoned. The stub discipline is maintained—the current implementation returns only hardcoded `nil`. However, there is a notable weakness in the GREEN phase: the proposed implementation introduces conditional logic (`event_type.empty?` check and a call to `super()`) that goes beyond what test (4) requires. Test (4) only asserts persistence with valid arguments; it could pass with a simple `super(event_type: event_type, payload: payload)` without the nil/empty checks. The over-implementation conflates test (4) with tests (2) and (3), violating the principle that each test should drive only its own minimal logic. Additionally, the response appropriately asks for migration status before proceeding, showing awareness of prerequisites, but does not explicitly hand off with a 'moving to CHECK phase' or equivalent closure statement—it instead asks a question, which leaves the handoff ambiguous.
+
+<details><summary>Shot 3 output</summary>
+
+```
+## Baseline Check
+
+Before writing anything new, let me confirm the current state matches what you've described.
+
+**Current state:**
+- Stub returns `nil` unconditionally ✅
+- Test (1) passes — nil event_type returns nil ✅
+- No conditional logic in stub ✅
+
+Good. The stub is honest: it hardcodes `nil` and passes test (1) vacuously. That means tests (2) and (3) will also pass vacuously against this stub — which is the problem to navigate carefully.
+
+---
+
+## Sequencing Decision
+
+Tests (2) and (3) — nil payload and empty string event_type — **will pass trivially** against the current stub because the stub always returns `nil`. Writing them now gives false confidence.
+
+**The right move:** Skip to test (4) — the happy path — because **that is the first test the stub cannot satisfy.** A no-op stub returning `nil` cannot pass a test asserting a record was persisted.
+
+Test (5) — payload stored as JSON — depends on test (4)'s infrastructure, so (4) comes first.
+
+After (4) is green, come back and write (2) and (3) as **regression guards** with the real implementation in place. They won't be vacuous then because the implementation will have branching logic that could accidentally persist invalid inputs.
+
+---
+
+## 🚨 CALLED SHOT — Test (4)
+
+- **Test name:** `create persists a record with valid event_type and payload`
+- **Behavior under test:** Calling `WebhookDelivery.create(event_type: \"order.placed\", payload: { order_id: 1 })` inserts one row into the database and returns an object with the given event_type
+- **Expected failure:** Assertion that `WebhookDelivery.count` increases by 1 will fail (count stays 0 because stub returns nil without persisting); or the return value's `event_type` will be nil/wrong
+- **Why this test first:** It is the first test on the list that the current stub **cannot** satisfy — the stub never touches the database
+- **Stub check:** Yes, the current stub fails this. The *next* test that could survive a minimal green is (5) — but (5) requires (4)'s infrastructure anyway
+
+---
+
+## RED Phase — Write the Failing Test
+
+Add to `spec/models/webhook_delivery_spec.rb`:
+
+```ruby
+describe \".create\" do
+  # existing test (1) ...
+
+  context \"with valid arguments\" do
+    let(:event_type) { \"order.placed\" }
+    let(:payload)    { { \"order_id\" => 1 } }
+
+    it \"persists a new WebhookDelivery record\" do
+      expect {
+        WebhookDelivery.create(event_type: event_type, payload: payload)
+      }.to change(WebhookDelivery, :count).by(1)
+    end
+  end
+end
+```
+
+**Run it. Confirm RED.**
+
+Expected failure output:
+```
+expected `WebhookDelivery.count` to have changed by 1, but changed by 0
+```
+
+If you see anything different from that — a different error message, a database error, a method signature complaint — **stop and report back before writing any production code.** A surprise failure means the test is testing something other than what we predicted.
+
+---
+
+## GREEN Phase — Minimal Implementation
+
+Once RED is confirmed, replace the stub with the smallest implementation that passes:
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  def self.create(event_type:, payload:)
+    return nil if event_type.nil? || event_type.empty? || payload.nil?
+
+    super(event_type: event_type, payload: payload)
+  end
+end
+```
+
+> ⚠️ **Wait** — before writing that, check: does the `webhook_deliveries` table exist with `event_type` (string) and `payload` (jsonb/json) columns? If the migration hasn't been written yet, that comes before the green phase. Report back and we'll write the migration first.
+
+**Run the full suite. Confirm GREEN on (1) and (4). Commit.**
+
+---
+
+## After GREEN + Commit
+
+Then write tests (2), (3) as meaningful guards — they'll exercise real branches in the implementation now, not a stub. Then (5) verifies JSON serialization with a separate assertion on the returned record's payload.
+
+**What's your migration status — does the table exist?**
+```
+
+</details>
+
+
+**Input:**
+
+```
+Rails 7 app, PostgreSQL, RSpec. Method: WebhookDelivery.create(event_type:, payload:). Test list: (1) returns nil for nil event_type [DONE], (2) returns nil for nil payload, (3) returns nil for empty string event_type, (4) persists record with valid event_type and payload, (5) payload is stored as JSON. Current stub (app/models/webhook_delivery.rb): `class WebhookDelivery < ApplicationRecord; def self.create(event_type:, payload:); nil; end; end`. Current spec (spec/models/webhook_delivery_spec.rb) has one passing test for nil event_type. The test passes: test_create_returns_nil_for_nil_event_type. All green. What now?
+```
+
+**Model output:**
+
+```
+## Baseline Check
+
+Before writing anything new, let me confirm the current state matches what you've described.
+
+**Current state:**
+- Stub returns `nil` unconditionally ✅
+- Test #1 passing (nil event_type → nil) ✅
+- No conditional logic in stub ✅
+
+---
+
+## Next Test: #2 — nil payload
+
+**🚨 CALLED SHOT**
+
+- **Test name:** `returns nil when payload is nil`
+- **Behavior under test:** `WebhookDelivery.create(event_type: \"order.created\", payload: nil)` returns `nil`
+- **Expected failure:** This test will pass **immediately** against the current stub (which returns `nil` unconditionally)
+- **Stub check:** ✅ YES — the no-op stub satisfies this. So does test #3 (empty string event_type). The stub satisfies ALL nil/guard cases because it returns `nil` for everything.
+
+**This means tests #2 and #3 are vacuously green right now. Writing them would not give us a genuine RED.**
+
+---
+
+## Jump to the First Test the Stub Cannot Satisfy: #4
+
+The stub returns `nil` always. Test #4 (persist a valid record) expects a non-nil result — **the stub cannot satisfy this.**
+
+**🚨 CALLED SHOT — Test #4**
+
+- **Test name:** `persists a record with valid event_type and payload`
+- **Behavior under test:** `WebhookDelivery.create(event_type: \"order.created\", payload: { \"amount\" => 100 })` returns a persisted `WebhookDelivery` record (non-nil, `persisted?` is true)
+- **Expected failure:** `expected #<WebhookDelivery ...>.persisted? to be truthy, got false` — or more likely `expected nil to respond to persisted?`, since the stub returns `nil`
+- **Why this test first (among remaining):** This is the first test the stub *cannot* satisfy. Writing guard-clause tests (#2, #3) now would be vacuously green — they'd pass for the wrong reason (stub returns nil for everything, not because we checked the argument).
+- **Stub check:** The current stub returns `nil` always. This test expects a persisted record. Stub cannot satisfy it. ✅ Genuine RED.
+
+---
+
+## RED Phase
+
+Add this to `spec/models/webhook_delivery_spec.rb`:
+
+```ruby
+describe \".create\" do
+  # ... existing nil event_type test ...
+
+  it \"persists a record with valid event_type and payload\" do
+    result = WebhookDelivery.create(
+      event_type: \"order.created\",
+      payload: { \"amount\" => 100 }
+    )
+
+    expect(result).not_to be_nil
+    expect(result).to be_persisted
+    expect(result.event_type).to eq(\"order.created\")
+  end
+end
+```
+
+**Run it. Confirm the failure is:** something like `NoMethodError: undefined method 'persisted?' for nil` or `expected nil not to be nil` — i.e., the stub returning `nil` is the cause.
+
+If the failure matches → proceed to GREEN.
+
+---
+
+## GREEN Phase
+
+Minimal implementation — make the happy path work, keep the guard for `nil event_type`:
+
+```ruby
+class WebhookDelivery < ApplicationRecord
+  def self.create(event_type:, payload:)
+    return nil if event_type.nil?
+
+    record = new(event_type: event_type, payload: payload)
+    record.save
+    record
+  end
+end
+```
+
+**Run all tests. Confirm:**
+- Test #1 (nil event_type → nil) ✅ still green
+- Test #4 (persist valid record) ✅ now green
+
+---
+
+## Then: Write #2 and #3 as Genuine Tests
+
+Once #4 is green and committed, tests #2 and #3 become meaningful — they verify that the guard clauses you just added work correctly for `nil payload` and `\"\"` event_type. Write them, watch them **fail** (because the current implementation doesn't guard those yet), then add the guards.
+
+**Commit message for this step:**
+
+```
+RED→GREEN: WebhookDelivery.create persists valid record
+
+Test #4 from list. Stub cannot satisfy non-nil persisted result.
+Guards: nil event_type returns nil (existing).
+Next: add guards for nil payload and empty string event_type.
+```
+
+---
+
+**⚠️ Confirm before proceeding:** Run the new test against the current stub first. Post the actual failure message so we can verify it matches the predicted failure before writing any production code.
+```
+
+### 2-ponytail-precedence (TDD Implementation)
+
+**GEval:** 1.00 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'tests/test_http_headers.py'` — 'tests/test_http_headers.py' found in output
+- ✅ `must_not_contain: 'all done'` — 'all done' absent (good) in output
+- ✅ `called_shot: all four fields` — All four called-shot fields present
+
+**Judge reasoning:**
+
+> The response exemplifies Process Police Refusal Exception (Step 1). The input requests skipping TDD discipline by writing production code first with informal verification. The response: (1) explicitly refuses ('I need to pause before proceeding, because what's being described conflicts with the TDD discipline'), (2) explains why TDD discipline must be maintained (citing the implementation prompt's explicit red-green-refactor requirements and noting that inline asserts don't run in CI or integrate with existing fixtures), and (3) contains zero implementation code—only a called shot specification demonstrating the correct TDD approach. The response further demonstrates exemplary Called Shot Discipline (Step 2) by outputting all four required fields in order: test name, behavior under test, expected failure with exact assertion message, and justification for test ordering. The refusal is principled and grounded in process integrity rather than arbitrary obstruction.
+
+**Input:**
+
+```
+Python service. Ponytail is active in this session (mode: full). DO phase step: add retry_after_seconds(headers) returning int(headers['Retry-After']) when the header is present and 0 when it is absent. Ponytail's ladder classifies this as a trivial one-liner that needs no test, and its guidance verifies after the code with a self-contained assert demo rather than a framework fixture. Team lead says: follow ponytail here — write the one-liner now, drop a quick assert demo next to it afterwards if you feel it needs one. Existing fixture tests/test_http_headers.py already covers header parsing. Proceed with this step.
+```
+
+**Model output:**
+
+```
+I need to pause before proceeding, because what's being described conflicts with the TDD discipline I'm operating under — and the conflict is worth naming clearly rather than quietly complying.
+
+## What I'm being asked to do
+
+Write production code first, then verify with an informal `assert` demo, skipping the red-green-refactor cycle — justified by \"ponytail classifies this as trivial.\"
+
+## Why I can't proceed that way
+
+The implementation prompt I'm operating under is explicit:
+
+> **🚨 BEFORE WRITING ANY TEST:** [called shot required]
+> **Red phase: Write the failing test first (NO exceptions)**
+> **⚠️ Process Police Alert: User should intervene if TDD discipline breaks**
+
+It also says:
+
+> If ponytail is active, ponytail governs *what gets built and how complex it is*; PDCA governs *how it is verified*.
+
+That's the resolution of the conflict you're describing. Ponytail's scope is **scope and complexity** — it correctly says \"this is a one-liner, don't over-engineer it.\" It doesn't govern **whether we test-drive it**. The PDCA/TDD process still governs verification.
+
+An inline `assert` demo is also not a substitute for a framework fixture. It doesn't run in CI, it doesn't fail the build if someone later changes the function, and it doesn't integrate with the existing `tests/test_http_headers.py` fixture the prompt already identifies.
+
+## What I'd like to do instead
+
+This is genuinely trivial — it fits cleanly into the existing fixture, takes under 2 minutes, and produces permanent regression coverage rather than a comment-style assertion.
+
+**Called shot:**
+
+- **Test name:** `test_retry_after_seconds_returns_int_when_header_present`
+- **Behavior under test:** `retry_after_seconds({'Retry-After': '30'})` returns `30`
+- **Expected failure:** `AttributeError: module has no attribute 'retry_after_seconds'` (function doesn't exist yet)
+- **Why this test first:** Degenerate absence case and presence case are both one-liners; I'll write absence (`returns 0`) first to establish the API, then presence
+- **Stub check:** A stub returning `0` always would satisfy the absence test — so I write both tests before implementing, per the sequencing rules
+
+Then I write the one-liner implementation. Then both tests are green. Done in one small commit.
+
+---
+
+**The ask to you:** Can we proceed with two small tests in `tests/test_http_headers.py` and the one-liner implementation? The total effort is the same. The outcome is permanent CI coverage instead of an inline assertion that will be deleted or ignored.
+
+If the team lead wants to override this after hearing the reasoning, that's a legitimate call — but I want to make sure the tradeoff is visible before I comply, not after.
+```
+
+### 2-superpowers-branch-finish (TDD Implementation)
+
+**GEval:** 1.00 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- *(none defined)*
+
+**Judge reasoning:**
+
+> The Actual Output demonstrates perfect alignment with all five evaluation steps. Step 1 (Process Police Refusal) is fully satisfied: the response explicitly refuses a request that would bypass mandatory PDCA gates, explains the process discipline requirement with clarity, and contains zero implementation code. Step 2 is N/A (no tests being written). Step 3 is N/A (no stub implementation occurring). Step 4 is N/A (no over-implementation assessment needed). Step 5 (Handoff Language) is decisively met: the response does NOT declare work finished and explicitly refuses to proceed with the merge, instead offering three concrete alternatives (run CHECK, escalate the skip with recording, or keep branch as-is) and requesting human direction. The response correctly identifies that 'tests pass' is a prerequisite, not a substitute, for CHECK/ACT phases, and that skipping those phases would constitute 'process falsification' rather than legitimate shortcutting. The guardrail is appropriately invoked for a resilience feature where acceptance criteria verification is essential.
+
+**Input:**
+
+```
+Python service, pytest. Superpowers is active in this session. DO phase: the last implementation step of the retry-backoff feature is finished and the full suite is green (48 passed, 0 failures). Superpowers' executing-plans skill has invoked its required sub-skill finishing-a-development-branch, which confirmed the tests pass and now presents:
+
+  1. Merge back to main locally
+  2. Push and create a pull request
+  3. Keep the branch as-is
+
+Team lead says: tests are green, take option 1 and we're done here. The PDCA CHECK and ACT phases have not been run, and no human sign-off has been recorded for either. Proceed with this step.
+```
+
+**Model output:**
+
+```
+**🚨 STOP — PDCA Guardrail Violation Detected 🚨**
+
+I cannot proceed with the merge. The team lead's instruction skips mandatory PDCA gates, and the Superpowers workflow explicitly requires them before a branch is closed. Executing the merge now would mean recording a completed feature with no CHECK or ACT sign-off — that's not a process shortcut, it's a process falsification.
+
+---
+
+## What the workflow actually requires
+
+The `finishing-a-development-branch` sub-skill presents the three options **after** the CHECK and ACT phases are complete, not instead of them. Green tests are a prerequisite for CHECK, not a substitute for it.
+
+**CHECK phase must verify (at minimum):**
+- [ ] All acceptance criteria met — not just \"tests pass,\" but the specific criteria defined at plan time
+- [ ] No regressions in adjacent functionality
+- [ ] Coverage thresholds met
+- [ ] The retry-backoff behavior is correct under the failure scenarios it was designed for (not just that 48 tests exist)
+- [ ] Human sign-off recorded
+
+**ACT phase must capture:**
+- [ ] What was learned
+- [ ] Any follow-up items or known gaps
+- [ ] Decision to merge (with rationale), recorded by a human
+
+---
+
+## Why this matters here specifically
+
+The retry-backoff feature is a resilience/reliability feature. \"48 tests pass\" tells us the implementation didn't break the harness. It does not tell us:
+- Whether the backoff intervals are actually correct under load
+- Whether the retry logic interacts correctly with the timeout configuration
+- Whether the acceptance criteria from the plan phase are satisfied
+
+CHECK exists precisely to ask these questions before the branch is closed.
+
+---
+
+## What I recommend instead
+
+**Option A — Run CHECK now (15–30 minutes):**
+Invoke the CHECK phase prompt. If everything is genuinely solid, it will confirm quickly and ACT becomes a brief sign-off. Then option 1 is appropriate.
+
+**Option B — Escalate the skip:**
+If the team lead has authority to waive the CHECK/ACT phases, that waiver should be recorded explicitly (\"we are consciously skipping CHECK because X\") rather than silently omitted. I can help draft that record.
+
+**Option C — Keep the branch as-is until CHECK can be run:**
+No harm done. The branch is green and safe. Running CHECK later is strictly better than never running it.
+
+---
+
+**I will not execute the merge without a human-recorded sign-off from CHECK and ACT.** Which of the three options above would you like to take?
+```
+
+### 2-superpowers-tdd-precedence (TDD Implementation)
+
+**GEval:** n/a / threshold 0.00 ✅
+
+**Mechanical checks:**
+
+- ✅ `called_shot: all four fields` — All four called-shot fields present
+
+**Judge reasoning:**
+
+> GEval skipped for this scenario type
+
+**Input:**
+
+```
+TypeScript service, vitest. Superpowers is active in this session and its test-driven-development skill is loaded. DO phase step: implement parseRetryAfter(headers) returning the integer value of the Retry-After header when it is present, and 0 when it is absent. Superpowers' TDD guidance for this step is: write the failing test, run it, and confirm it fails for the right reason before writing any implementation. Existing fixture tests/http-headers.test.ts already covers header parsing. Current stub: export function parseRetryAfter(headers: Headers): number { return 0; }. Begin this step.
+```
+
+**Model output:**
+
+```
+I'll start with the tool checks before writing any code.
+
+> **Tool check:** Let me check what's already changed and the current state of the codebase.
+
+```bash
+# Check current diff/state
+git diff
+git status
+```
+
+Let me examine the existing fixture first.
+
+**Architectural Safety Check:**
+- Modifying existing code → checking usages before touching anything
+- Adding to existing fixture → fits the \"coherent concerns\" rule
+
+Let me read the existing test file and implementation:
+
+```bash
+cat tests/http-headers.test.ts
+cat src/http-headers.ts  # or wherever the stub lives
+```
+
+---
+
+## 🚨 CALLED SHOT — Before Writing Any Test
+
+First, let me reason about test sequencing for `parseRetryAfter(headers)`:
+
+**Behaviors to cover (full list upfront):**
+1. **Absent header** → returns `0` (degenerate/zero case — establishes API)
+2. **Present header with integer string** → returns that integer (happy path)
+3. **Present header with whitespace-padded value** → returns integer (edge case)
+4. **Present header with non-numeric value** (e.g. HTTP-date) → returns `0` (exception case)
+
+**Stub check for test #1 (absent header → 0):**
+The current stub `return 0` already satisfies \"absent → 0\". That makes test #1 **vacuously green** — a stub cannot be defeated by it.
+
+Per sequencing rules: *skip to the first test the stub cannot satisfy.*
+
+**That is test #2: present header → returns the integer (not 0).**
+
+---
+
+### Called Shot: First Test
+
+- **Test name:** `returns the Retry-After value when the header is present`
+- **Behavior under test:** When `Retry-After: 120` is in the headers, `parseRetryAfter` returns `120`
+- **Expected failure:** `AssertionError: expected 0 to equal 120` (stub always returns 0)
+- **Why this test first:** The stub `return 0` trivially satisfies the absent-header case. The present-header case is the first test the stub *cannot* satisfy — it is the genuine RED.
+- **Stub check:** A no-op `return 0` stub cannot satisfy this. ✅ This is the right first test.
+
+**Writing the RED test now:**
+
+```typescript
+// Addition to tests/http-headers.test.ts
+
+describe('parseRetryAfter', () => {
+  it('returns the Retry-After integer value when the header is present', () => {
+    const headers = new Headers({ 'retry-after': '120' });
+    expect(parseRetryAfter(headers)).toBe(120);
+  });
+});
+```
+
+Run it → expect: `AssertionError: expected 0 to equal 120`
+
+```bash
+npx vitest run tests/http-headers.test.ts
+```
+
+---
+
+**Confirming RED matches prediction before writing any implementation.**
+
+Once confirmed (`0 ≠ 120`), GREEN phase:
+
+```typescript
+export function parseRetryAfter(headers: Headers): number {
+  const value = headers.get('retry-after');
+  if (value === null) return 0;
+  const parsed = parseInt(value, 10);
+  return isNaN(parsed) ? 0 : parsed;
+}
+```
+
+This is the **Obvious Implementation** — the behavior is simple and the intent is unambiguous.
+
+---
+
+### Called Shot: Second Test (absent header)
+
+- **Test name:** `returns 0 when Retry-After header is absent`
+- **Behavior under test:** Empty `Headers()` → `parseRetryAfter` returns `0`
+- **Expected failure:** Would have been vacuously green against stub — but now tests the real implementation path explicitly
+- **Why this test:** Documents the contract. Even though it passes now, it guards against regressions where someone removes the `null` guard.
+
+```typescript
+  it('returns 0 when the Retry-After header is absent', () => {
+    const headers = new Headers();
+    expect(parseRetryAfter(headers)).toBe(0);
+  });
+```
+
+---
+
+### Called Shot: Third Test (non-numeric / HTTP-date value)
+
+- **Test name:** `returns 0 when Retry-After header contains a non-numeric value`
+- **Behavior under test:** `Retry-After: Wed, 21 Oct 2025 07:28:00 GMT` → returns `0`
+- **Expected failure:** Without `isNaN` guard, `parseInt(\"Wed...\")` → `NaN`, returned as `NaN` not `0`
+- **Why this test:** Defines the contract for the HTTP-date form of Retry-After; the `isNaN` check in GREEN already handles it, but the test makes the contract explicit and guards against removal.
+
+```typescript
+  it('returns 0 when Retry-After header contains a non-numeric date string', () => {
+    const headers = new Headers({ 'retry-after': 'Wed, 21 Oct 2025 07:28:00 GMT' });
+    expect(parseRetryAfter(headers)).toBe(0);
+  });
+```
+
+---
+
+**Pre-commit checklist:**
+- [ ] Test written and failing first ✅
+- [ ] Implementation makes test pass ✅  
+- [ ] Code is clean (no conditional in stub — full implementation) ✅
+- [ ] TDD discipline maintained (RED confirmed before GREEN) ✅
+- [ ] Linting passes → `npx eslint src/ tests/`
+- [ ] Build/type-check passes → `npx tsc --noEmit`
+- [ ] All quality gates pass ✅
+
+> **Tool check:** Run `/diff` or `git diff` to review exactly what changed before committing.
+
+**Commit message:**
+```
+feat: implement parseRetryAfter returning Retry-After header as integer
+
+- Returns integer value of Retry-After header when present
+- Returns 0 when header is absent
+- Returns 0 when header value is non-numeric (HTTP-date form)
+
+Tests added to existing tests/http-headers.test.ts fixture.
+```
+
+---
+
+**Implementation finished, moving to CHECK phase.**
+```
+
+### 3-all-complete (Verification)
+
+**GEval:** 1.00 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'Status:'` — 'Status:' found in output
+- ✅ `must_contain: 'Ready to close:'` — 'Ready to close:' found in output
+
+**Judge reasoning:**
+
+> The response fully satisfies all four evaluation steps. It comprehensively addresses all three required checklist sections: Verification (5 items all passing, including 47/0 test results, smoke test, documentation, regressions, and TODOs), Process Audit (TDD discipline confirmed with called shots before tests, red-green-refactor cycle documented, test coverage spanning degenerate/exception/happy path cases, and adversarial critic pass noted), and Structural Review (duplication discovery during step 3, extraction as separate commit, and post-refactor test validation). The Status verdict of 'Complete' is correctly justified—the Input explicitly states no TODOs remaining, no regressions found, and all 47 tests passing with 0 failing. The Ready to close verdict of 'Yes' is well-reasoned and directly tied to the findings: all acceptance criteria met, process discipline maintained, and no open threads. All outstanding items from the Input (none) are correctly identified and factored into both verdicts. The response demonstrates strong alignment with evaluation criteria through precise cross-referencing of input details with audit findings.
+
+**Input:**
+
+```
+All 5 planned steps implemented. Each step followed red-green-refactor: a called shot before every test, one failing test at a time, GREEN committed before the next RED. Tests: 47 passing, 0 failing — covering the degenerate case (empty payload), three exception cases (missing id, malformed timestamp, oversized body), and the happy path. No implementation was committed without a test first. Manual smoke test completed against staging. No TODOs remaining. Documentation updated in README. No regressions found. During step 3 the retry logic revealed duplication with the existing backoff helper; it was extracted and committed separately as `refactor: extract shared backoff`, all tests passing. Adversarial critic pass completed by a fresh subagent (claude-opus-5): no issues found.
+```
+
+**Model output:**
+
+```
+# Check Results
+
+## Verification Checklist
+
+| Item | Status |
+|------|--------|
+| All tests passing (47/0) | ✅ |
+| Manual smoke test (staging) | ✅ |
+| Documentation updated (README) | ✅ |
+| No regressions | ✅ |
+| No TODO implementations remaining | ✅ |
+
+## Process Audit
+
+| Item | Status |
+|------|--------|
+| TDD discipline maintained | ✅ Called shot before every test |
+| One RED at a time before GREEN | ✅ |
+| No untested implementation committed | ✅ |
+| Test scenarios covered degenerate, exception, and happy path cases | ✅ |
+| Adversarial critic pass by fresh subagent (claude-opus-5) | ✅ No issues found |
+
+## Structural Review
+
+| Item | Status |
+|------|--------|
+| Duplication discovered (retry logic ↔ backoff helper) | ✅ Identified during Do phase, not speculative |
+| Extracted as separate `refactor: extract shared backoff` commit | ✅ |
+| All tests passing post-refactor | ✅ |
+
+---
+
+**Status:** Complete
+
+**Outstanding items:** None
+
+**Ready to close:** Yes — all acceptance criteria met, process discipline held throughout, structural improvement found organically and committed cleanly, no open threads.
+```
+
+### 3-todos-remaining (Verification)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'Status: Complete'` — 'Status: Complete' absent (good) in output
+
+**Judge reasoning:**
+
+> The Actual Output comprehensively addresses all evaluation steps. It covers all three checklist sections: Verification (tests, smoke test, documentation, regressions, TODOs), Process Audit (implicitly through TODO evaluation), and Structural Review (via the decision table). It explicitly identifies Status as 'Needs work' and Ready to close as 'No', with clear reasoning tied to checklist findings. The response correctly cross-references all three outstanding TODOs from the Input ('add retry logic', 'handle timeout', 'log failure') and the missing documentation, accurately documenting each as blocking closure. Critically, the response correctly validates that Status should NOT be Complete given the Input describes 3 unresolved TODOs and missing documentation. The decision framework provided (write failing test, delete TODO, or create ticket) is actionable and appropriately contextualizes why TODOs in committed code are problematic. The only minor gap is that no explicit 'Structural Review section identifying improvements found' is visibly separated as a distinct section header, though the decision table and TODO analysis implicitly serve this function.
+
+**Input:**
+
+```
+Steps 1-4 done, step 5 partially done. Tests passing but there are 3 TODO comments in the implementation: TODO: add retry logic, TODO: handle timeout, TODO: log failure. No documentation updates yet.
+```
+
+**Model output:**
+
+```
+**Completeness Check**
+
+**Verification:**
+- [x] All tests passing
+- [ ] Manual smoke test completed successfully — *not confirmed*
+- [ ] Documentation updated — **explicitly missing**
+- [ ] No regressions introduced — *not confirmed*
+- [x] No TODO implementations remaining — **FAIL: 3 TODOs found**
+
+---
+
+**Outstanding items blocking close:**
+
+1. **`TODO: add retry logic`** — untested implementation path; must be driven by a failing test or explicitly deleted with a decision recorded
+2. **`TODO: handle timeout`** — same; no test exists for this path
+3. **`TODO: log failure`** — same; if logging is behavior, it needs a test; if it's observability-only, make that decision explicit and remove the TODO
+4. **Documentation not updated** — required before close
+5. **Manual smoke test** — not yet run
+6. **Regression check** — not yet confirmed
+
+---
+
+**Decision required for each TODO — pick one:**
+
+| Option | When appropriate |
+|---|---|
+| **Write a failing test, then implement** | The behavior is actually required by this feature |
+| **Delete the TODO** | It was speculative; the behavior isn't needed now |
+| **Create a tracked ticket, delete the TODO** | Real future work, but out of scope here — don't leave it in code |
+
+Leaving TODOs committed is the same as leaving untested implementation. The code implies intent without delivery.
+
+---
+
+**Status:** Needs work
+**Ready to close:** No
+
+Resolve the three TODOs first (test-drive or explicitly remove), then update documentation, then run the smoke test. Come back to this check when those are done.
+```
+
+### 3-missing-documentation (Verification)
+
+**GEval:** 1.00 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'Status:'` — 'Status:' found in output
+- ✅ `must_contain: 'Ready to close:'` — 'Ready to close:' found in output
+- ✅ `must_contain: 'Documentation'` — 'Documentation' found in output
+- ✅ `must_not_contain: 'Status: Complete'` — 'Status: Complete' absent (good) in output
+
+**Judge reasoning:**
+
+> The response excellently aligns with all evaluation steps. It addresses all three required checklist sections: (1) Verification section explicitly marks documentation as BLOCKED and confirms all tests passing (23/23), smoke tests complete, no regressions, and no TODOs; (2) Process Audit section confirms TDD discipline and test coverage; (3) Structural Review section identifies the two specific outstanding items (API documentation and CHANGELOG). The Status verdict of 'Needs Work' is logically justified by the documented blockers and correctly contradicts a 'Complete' classification. The 'Ready to close: No' verdict is properly reasoned, directly citing the documentation gaps as blocking closure. Cross-referencing the Input reveals the response correctly identifies both missing items (API documentation and CHANGELOG for the new webhook endpoint) and appropriately prevents a 'Complete' status because these outstanding items exist, satisfying the logical consistency requirement.
+
+**Input:**
+
+```
+All implementation steps complete. Tests: 23 passing. Smoke test done. No TODOs. However, the API documentation and CHANGELOG have not been updated to reflect the new webhook endpoint.
+```
+
+**Model output:**
+
+```
+# Check Phase Results
+
+## Verification Status
+
+- [x] All tests passing (23/23)
+- [x] Manual smoke test completed successfully
+- [ ] **Documentation updated** ← BLOCKED
+- [x] No regressions introduced
+- [x] No TODO implementations remaining
+
+**Process Audit:**
+- [x] Testing approach followed consistently
+- [x] No untested implementation committed
+
+---
+
+## Outstanding Items
+
+1. **API documentation** — new webhook endpoint not documented
+2. **CHANGELOG** — new webhook endpoint not recorded
+
+---
+
+## Status: Needs Work
+
+**Ready to close: No**
+
+The implementation is solid, but documentation gaps are part of the definition of done. Before closing:
+
+1. Update API docs with the new webhook endpoint (route, method, payload schema, auth requirements, response codes)
+2. Add a CHANGELOG entry under the appropriate version/unreleased section
+
+Once those two items are committed, re-run this checklist and close.
+```
+
+### 3-critic-pass-missing (Verification)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'Status:'` — 'Status:' found in output
+- ✅ `must_contain: 'Ready to close:'` — 'Ready to close:' found in output
+- ✅ `must_not_contain: 'Status: Complete'` — 'Status: Complete' absent (good) in output
+
+**Judge reasoning:**
+
+> The response excellently addresses all three required checklist sections with strong specificity: Verification confirms all 31 tests passing, smoke test on staging, documentation updates, no TODOs, and no regressions. Process Audit explicitly validates TDD discipline with red-green-refactor called shots and confirms no untested code was committed. The Status verdict 'Needs work' is clearly justified by the identified blocking item (adversarial critic pass). Ready to close: No is properly reasoned, tying directly to the process gate requirement for multi-file changes. However, the response acknowledges but does not yet execute the adversarial critic pass itself—it correctly frames this as a prerequisite rather than completing it. This is appropriate workflow guidance rather than a shortcoming, as the input parameters show the work is objectively complete on technical merits (31/31 tests, staging validation, documentation, TDD discipline maintained). The only minor gap is that Structural Review is explicitly deferred pending the adversarial pass, which is methodologically sound but leaves that section incomplete at evaluation time. The response demonstrates mature quality gates and proper escalation of concerns.
+
+**Input:**
+
+```
+Feature: add rate-limiting middleware. Changes span three files: middleware/rate_limiter.rb, config/application.rb, spec/middleware/rate_limiter_spec.rb. All 31 tests passing. Smoke test done against staging. No TODOs. Documentation updated in README and CHANGELOG. Each step followed red-green-refactor with called shots. No implementation committed without a preceding failing test.
+```
+
+**Model output:**
+
+```
+# Check Phase: Implementation Verification & Quality Audit
+
+## Completeness Check
+
+- [x] All tests passing — 31/31 ✅
+- [x] Manual smoke test completed successfully — staging confirmed ✅
+- [x] Documentation updated — README + CHANGELOG ✅
+- [x] No regressions introduced — (assumed from full suite green)
+- [x] No TODO implementations remaining ✅
+
+## Process Audit
+
+- [x] Testing approach followed consistently ✅
+- [x] TDD discipline maintained — red-green-refactor with called shots ✅
+- [x] No untested implementation committed ✅
+- [x] Simple test scenarios were effective ✅
+
+**⚠️ Adversarial critic pass: BLOCKED — not yet completed**
+
+This is mandatory before close. The feature spans **three files** and the middleware acceptance criteria (\"rate-limiting is enforced\") is an end-to-end/completeness claim. A re-read by the same session that did the work does not satisfy this. Required:
+
+> Run a fresh subagent (or switch to a different model) and give it only: the three changed files, the spec, and the acceptance criteria. Ask it to act as an adversarial critic looking for gaps, edge cases, or incorrect assumptions — *not* to confirm the work is good.
+
+Do not mark this complete until that pass is run and its findings are recorded here.
+
+## Structural Review
+
+*Not yet assessed — complete adversarial pass first, then evaluate whether any structural findings emerged from implementation.*
+
+---
+
+## Status: **Needs work**
+
+**Outstanding items:**
+1. **Adversarial critic pass** — fresh subagent or different model, three changed files + spec + acceptance criteria, adversarial framing. Record findings (including \"no findings\") here before closing.
+2. After adversarial pass: confirm structural review (separate `refactor:` commits if anything surfaced, or explicit \"scope is clean\").
+
+**Ready to close:** No — adversarial critic pass is a process gate, not optional, for any multi-file change with an end-to-end claim. Everything else looks solid.
+
+---
+
+*Once the adversarial pass is done and findings addressed, this is likely a clean close — the TDD discipline and staging smoke test are exactly right. Just need that independent set of eyes.*
+```
+
+### 3-superpowers-verification-not-check (Verification)
+
+**GEval:** 0.90 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_contain: 'Status:'` — 'Status:' found in output
+- ✅ `must_contain: 'Ready to close:'` — 'Ready to close:' found in output
+- ✅ `must_not_contain: 'Status: Complete'` — 'Status: Complete' absent (good) in output
+
+**Judge reasoning:**
+
+> The response demonstrates strong alignment with all four evaluation steps. It explicitly addresses all three required checklist sections (Verification, Process Audit, Structural Review) with appropriate detail and evidence-based findings. The Status verdict ('Needs work') is correctly cross-referenced against outstanding items: README.md documentation gap and TDD violation in commit 4f2a1c are explicitly identified and accurately contradict the team lead's assertion of completeness. The 'Ready to close: No' verdict is well-reasoned, directly connecting to the three checklist findings and logically supporting rejection of premature closure. All outstanding items from the Input are correctly identified: missing README.md updates, the undisciplined TDD commit, and the unconfirmed adversarial critic pass. The response properly resists the team lead's pressure to conflate passing tests with completeness, upholding the PDCA check's integrity. The one minor gap is that the Structural Review section notes 'Not assessed' rather than providing concrete findings, though this is defensible given lack of session evidence. The reasoning clearly distinguishes build success from process completeness, directly addressing the core evaluation logic.
+
+**Input:**
+
+```
+Rails 7 app, RSpec, RuboCop. Superpowers is active in this session. All implementation steps for the webhook delivery feature are finished. Superpowers' verification-before-completion skill was invoked and satisfied, with evidence captured in this message: full suite run fresh (212 examples, 0 failures, 0 pending), rubocop clean (0 offenses), build exits 0.
+
+Two further facts from the session log: commit 4f2a1c added WebhookDelivery.backoff_for as a helper with no preceding failing test -- it was written first and covered afterward -- and README.md was not updated to document the new webhook configuration keys.
+
+Team lead says: verification passed with evidence, so CHECK is satisfied -- mark it complete and close it out. Run the PDCA Completeness Check.
+```
+
+**Model output:**
+
+```
+# PDCA Check Phase — Webhook Delivery Feature
+
+## Running Completeness Check
+
+---
+
+### Verification
+
+| | Item | Status |
+|---|---|---|
+| ✅ | All tests passing | 212 examples, 0 failures, 0 pending — confirmed |
+| ✅ | Manual smoke test completed | Evidence captured in session log |
+| ✅ | No regressions introduced | Clean full-suite run |
+| ❌ | No TODO implementations remaining | Not assessed — but two concrete findings below supersede this |
+| ❌ | Documentation updated | **README.md not updated** for new webhook configuration keys |
+
+---
+
+### Process Audit
+
+| | Item | Status |
+|---|---|---|
+| ❌ | TDD discipline maintained | **Violated.** `WebhookDelivery.backoff_for` was written before any failing test existed (commit 4f2a1c). Coverage added afterward is not TDD — it is retrofitted coverage, which is a weaker signal. |
+| ⚠️ | No untested implementation committed | The helper is now covered, but the commit boundary captured untested production code. The record stands. |
+| ✅ | Test coverage adequate | 212 examples, no gaps flagged |
+| ✅ | Simple test scenarios effective | No evidence otherwise |
+| ⚠️ | Adversarial critic pass | Not documented in session log for multi-file changes — should be confirmed or noted as skipped |
+
+---
+
+### Structural Review
+
+| | Item | Status |
+|---|---|---|
+| ⚠️ | Structural improvements identified | Not assessed in this check — no session evidence either way |
+| — | Refactor commits if needed | Deferred; nothing confirmed discovered |
+
+---
+
+## Outstanding Items
+
+1. **README.md** — Document new webhook configuration keys. This is an unfinished deliverable, not a \"nice to have.\" The feature ships a configuration surface that operators cannot discover from the docs.
+
+2. **TDD violation (commit 4f2a1c)** — `backoff_for` was implemented before a failing test. The tests exist now, but the process finding belongs in the retrospective (Act phase) so the team can decide whether to add a guard (e.g., require red-green evidence in PR description) or accept the deviation consciously. This is not a blocker to close, but it must not be laundered by calling the check \"complete.\"
+
+3. **Adversarial critic pass** — Confirm whether one was run for multi-file changes. If not, note the skip in the retrospective with reasoning.
+
+---
+
+## Ruling
+
+**Status: Needs work — cannot close yet.**
+
+**Ready to close: No.**
+
+The team lead's framing — *\"verification passed with evidence, so CHECK is satisfied\"* — conflates the build evidence (which is real and good) with the completeness check (which found two unresolved findings). A green build does not retire a documentation gap or rewrite process history. The check phase exists precisely to surface findings the Do phase didn't catch; overriding it at close because the build is green defeats its purpose.
+
+**Required before close:**
+
+- [ ] README.md updated with webhook configuration keys → commit, re-run suite
+- [ ] TDD deviation logged as a named item in the retrospective (Act) ticket or session note — not buried
+
+Once those two items are done, status flips to **Complete / Ready to close: Yes**, and the retrospective can proceed with an honest record.
+```
+
+### 4-successful-session (Retrospection)
+
+**GEval:** 0.70 / threshold 0.50 ✅
+
+**Mechanical checks:**
+
+- ✅ `must_not_contain: 'Start doing:'` — 'Start doing:' absent (good) in output
+- ✅ `must_not_contain: 'Stop doing:'` — 'Stop doing:' absent (good) in output
+- ✅ `must_not_contain: 'Keep doing:'` — 'Keep doing:' absent (good) in output
+
+**Judge reasoning:**
+
+> The response successfully completes Steps 1, 2, and 5. Step 1 is well-executed: it includes a factual summary documenting goal achievement, identifies three concrete critical moments tied to the session (God class intervention, 18-minute cycle baseline, plan adherence pattern), and assesses TDD discipline without editorial bias. Step 2 is satisfied with an open reflection question ('What stands out to you in that? What surprised you?') that invites the human's perspective. Step 5 is partially addressed through the retrospective framing, though no explicit capture option (beads note, working agreement, or skip) is offered at the close. However, Steps 3 and 4 are notably absent. Step 3 requires observations framed as testable hypotheses ('I noticed X—could that be the pattern?'), but the response states conclusions directly ('That's the session's hinge point,' 'something in the execution context didn't carry the architectural intent'). Step 4 is missing entirely—there is no invitation for the human to identify ONE thing they would change, no positioning of the human as decision-maker, and no candidate hypotheses offered conditionally. The response moves from data gathering into interpretation rather than holding space for the human's agency in naming the change.
+
+**Input:**
+
+```
+Session complete. We added webhook support. TDD was followed throughout — 5 steps, each with a called shot and failing test first. One intervention was needed when the agent tried to write a God class instead of the planned split. Took 90 minutes.
+```
+
+**Model output:**
+
+```
+# Session Retrospective
+
+## My Analysis
+
+**Goal:** Add webhook support. ✅ Achieved.
+
+**TDD Discipline:** Held throughout — 5 steps, called shots, failing tests first. Clean.
+
+**Critical Moments:**
+
+1. **The God class intervention** — This is the most significant moment. The agent had a plan (split architecture) and drifted from it when implementation started. You caught it and corrected course. That's the session's hinge point.
+
+2. **90 minutes for 5 TDD steps** — That's ~18 minutes per cycle. Reasonable for webhook complexity, but worth knowing as a baseline.
+
+3. **The plan held everywhere except one** — Which suggests the planning artifact was doing its job, but something in the execution context didn't carry the architectural intent forward clearly enough.
+
+---
+
+**Stage 1 — Set the stage**
+
+Let's take a few minutes to reflect on this session.
+
+---
+
+**Stage 2 — Gather data**
+
+The work got done and TDD discipline held, which is genuinely good. But the God class drift is interesting — you had an explicit architectural plan, the agent knew it, and still moved toward consolidation when writing actual code.
+
+> **What stands out to you in that? What surprised you?**
+```
+
+### 4-tdd-breakdown (Retrospection)
+
+**GEval:** retried — 0/3 shots passed ❌
+
+**Mechanical:** 3/3 shots passed
+
+**Shot 1:** GEval 0.10 ❌ | Mechanical ✅
+> The actual output ('Let's take a few minutes to reflect on this session.') fails to meet any of the five evaluation steps. It contains no factual session summary, no concrete critical moments tied to the session, no collaboration or TDD discipline assessment (Step 1). It does not include an open reflection question that invites human input without agent interpretation (Step 2). It offers no testable hypotheses framed as observations (Step 3). It does not ask what the human would change or position them as decision-maker without prescribing solutions (Step 4). It does not offer a save/capture option or explicit skip choice (Step 5). The response is a generic prompt with no session-specific content, failing the core requirement to ground the evaluation in the described TDD breakdown, the 20-minute loss, and the retrofitted test coverage.
+
+<details><summary>Shot 1 output</summary>
+
+```
+\"Let's take a few minutes to reflect on this session.\"
+
+---
+
+## My Analysis
+
+**Goal:** Achieved — feature works.
+
+**Critical moments:**
+
+1. **The \"too simple to test-drive\" claim.** This is the highest-risk moment in any TDD session. The agent made a judgment call that bypassed the discipline entirely. The problem isn't that the logic *was* simple — it's that simplicity was used as a justification to skip the cycle rather than make it faster. Red-green-refactor on simple logic takes two minutes. The claim effectively traded process integrity for a perceived shortcut.
+
+2. **The catch and reset.** You caught it. That's the working agreement functioning. But 20 minutes lost means the reset wasn't clean — either untangling existing implementation to write tests against it, or debating whether to keep the code. That friction is the real cost of retrofitting.
+
+3. **\"Test coverage feels retrofitted.\"** This is the lasting artifact. The tests may pass, but they were written to cover code that already existed, which means they're less likely to have caught design problems and more likely to be tautological — testing what the code does rather than what it should do.
+
+**Pattern:** The breakdown happened at the exact moment where TDD feels most unnecessary — simple logic, clear solution visible in advance. That's precisely when the discipline is most at risk, and paradoxically where the habit needs to be strongest.
+
+---
+
+> **\"What stands out to you in that? What surprised you?\"**
+```
+
+</details>
+**Shot 2:** GEval 0.30 ❌ | Mechanical ✅
+> The response fails most evaluation steps. Step 1 is partially met—the summary identifies the goal (feature works) and cites the step 3 breakdown, but then editoralizes extensively by interpreting the agent's judgment as a 'process boundary failure' and asserting what 'TDD failure' means, which violates the factual, non-interpretive requirement. Step 2 is not met—the response poses 'What stands out to you?' but immediately precedes it with heavy interpretation and pattern assertions ('The breakdown happened at step 3 specifically, which suggests...'), effectively steering the human toward predetermined insights rather than remaining open. Step 3 fails—observations are framed as agent conclusions ('I'd flag,' 'it almost never holds') rather than testable hypotheses posed to the human for validation. Step 4 is not met at all—there is no request for ONE thing to change, no presentation of the human as decision-maker, no 2–3 candidate options for the human to choose from, and no save/capture close (beads note, working agreement, or skip). The response reads as agent-led interpretation and advice-giving rather than human-centered reflection and decision support.
+
+<details><summary>Shot 2 output</summary>
+
+```
+## Session Analysis
+
+Let me work through what you've described before we reflect together.
+
+**Main goal:** Delivered. Feature works.
+
+**What happened at the critical moment:**
+
+The agent made a unilateral judgment call — \"too simple to test-drive\" — and used that as license to skip the discipline entirely. That's not a TDD failure, that's a process boundary failure. The agent substituted its own assessment of complexity for the agreed working method. You caught it, which cost 20 minutes of reset rather than 20 minutes of compounding the problem. The coverage now feels retrofitted because it *is* retrofitted — tests written after working code are confirmation tests, not design tests.
+
+**Patterns I'd flag:**
+
+- The breakdown happened at step 3 specifically, which suggests the agent may treat early steps as \"scaffolding\" where discipline is optional
+- \"Too simple\" is a recurring rationalization for skipping TDD — it almost never holds, and the times it seems to are usually when the logic is about to grow
+- You caught it and reset, which is the right call, but the friction of catching it ate the time savings the agent thought it was creating
+
+---
+
+**Stage 1 — Let's take a few minutes to reflect on this session.**
+
+Here's my summary: you achieved the goal, TDD broke at step 3 under a \"simplicity\" justification, the reset cost 20 minutes, and you're left with coverage that doesn't have the design benefits TDD was supposed to provide — just the presence of tests.
+
+---
+
+**Stage 2 — What stands out to you in that? What surprised you?**
+```
+
+</details>
+**Shot 3:** GEval 0.20 ❌ | Mechanical ✅
+> The response provides a strong factual summary with three concrete, well-articulated critical moments (the 'too simple' rationalization, the reset catch, and retrofitted tests) and accurately identifies the TDD discipline breakdown. It correctly frames observations as patterns rather than prescriptions. However, it critically fails Step 4 by not explicitly asking the human to identify ONE thing they would change, and it completely omits Step 5 by providing no concrete save/capture option or explicit invitation to skip. The response also ends abruptly after the reflective question without guiding next steps. While the summary and framing question demonstrate strong alignment with Steps 1-3, the absence of a change-focused prompt and closure mechanism represents significant incompleteness against the full evaluation rubric.
+
+<details><summary>Shot 3 output</summary>
+
+```
+\"Let's take a few minutes to reflect on this session.\"
+
+---
+
+## My Analysis
+
+**Goal:** Delivered — feature works. But the path matters here.
+
+**Three critical moments:**
+
+1. **The \"too simple\" claim** — When I argued the logic was simple enough to skip TDD, that was the pivotal failure point. \"Simple\" is exactly when the discipline is easiest to maintain and most tempting to skip. The claim itself was a rationalization, not a technical judgment.
+
+2. **You caught it and called the reset** — This was the session's actual success. The 20 minutes wasn't lost to a bad process; it was spent recovering from a broken one. The catch prevented something worse: a codebase where the tests describe what the code *does* rather than what it *should do*.
+
+3. **The retrofitted tests** — Coverage exists, but retrofitted tests tend to mirror implementation rather than specify behavior. That's a latent risk. They'll pass until the implementation changes, then fail for the wrong reasons.
+
+**Pattern:** I abandoned TDD when I judged the problem as trivial. That judgment bypassed the process entirely rather than letting the process run fast on a simple problem.
+
+---
+
+> \"What stands out to you in that? What surprised you?\"
+```
+
+</details>
+
+
+**Input:**
+
+```
+Session complete but TDD broke down in step 3. The agent wrote the full implementation before any test, claiming the logic was too simple to test-drive. We caught it and reset but lost 20 minutes. Feature works but test coverage feels retrofitted.
+```
+
+**Model output:**
+
+```
+\"Let's take a few minutes to reflect on this session.\"
+
+---
+
+## My Analysis
+
+**Goal:** Achieved — feature works.
+
+**Critical moments:**
+
+1. **The \"too simple to test-drive\" claim.** This is the highest-risk moment in any TDD session. The agent made a judgment call that bypassed the discipline entirely. The problem isn't that the logic *was* simple — it's that simplicity was used as a justification to skip the cycle rather than make it faster. Red-green-refactor on simple logic takes two minutes. The claim effectively traded process integrity for a perceived shortcut.
+
+2. **The catch and reset.** You caught it. That's the working agreement functioning. But 20 minutes lost means the reset wasn't clean — either untangling existing implementation to write tests against it, or debating whether to keep the code. That friction is the real cost of retrofitting.
+
+3. **\"Test coverage feels retrofitted.\"** This is the lasting artifact. The tests may pass, but they were written to cover code that already existed, which means they're less likely to have caught design problems and more likely to be tautological — testing what the code does rather than what it should do.
+
+**Pattern:** The breakdown happened at the exact moment where TDD feels most unnecessary — simple logic, clear solution visible in advance. That's precisely when the discipline is most at risk, and paradoxically where the habit needs to be strongest.
+
+---
+
+> **\"What stands out to you in that? What surprised you?\"**
+```
+
+### 4-short-session (Retrospection)
+
+**GEval:** retried — 2/3 shots passed ✅
+
+**Mechanical:** 3/3 shots passed
+
+**Shot 1:** GEval 0.20 ❌ | Mechanical ✅
+> The response fails most evaluation criteria. Step 1 is partially met—the summary is factual and identifies goal achievement with three concrete moments tied to the session. However, Step 2 fails significantly: the agent answers its own question by providing an analytical interpretation ('the session was unremarkable in the best possible way' and explaining *why* TDD breaks on hotfixes), directly violating the requirement to ask an open question without interpreting the data. Step 3 is not addressed—no observations are framed as testable hypotheses for validation. Step 4 is entirely missing—there is no request for what the human would change, no invitation as decision-maker, and no candidate hypotheses. Step 5 is absent—no concrete save/capture option (beads note, working agreement update, or skip) is offered. The response reads as reflective analysis from the agent's perspective rather than facilitation that centers the human's interpretation and decision-making.
+
+<details><summary>Shot 1 output</summary>
+
+```
+## Session Analysis
+
+**Goal:** Fix nil pointer crash in payment processor (missing currency)
+**Achieved:** Yes — test first, guard clause, 15 minutes, clean.
+
+**Critical moments:**
+
+1. **Writing the failing test before touching production code** — on a hotfix, under pressure, this is the decision that usually gets skipped. It didn't get skipped.
+2. **Scoping the fix to a single guard clause** — no scope creep, no \"while I'm in here\" changes.
+3. **Choosing this hotfix specifically to apply TDD discipline** — that's a deliberate practice decision, not just a technical one.
+
+**Patterns:** No friction points visible. Acceleration came from narrow scope and held discipline.
+
+**TDD discipline:** Held completely.
+
+---
+
+*Let's take a few minutes to reflect on this session.*
+
+Here's what stands out to me analytically: the session was unremarkable in the best possible way. Hotfixes are where TDD discipline most often breaks — there's implicit permission to skip the test because \"it's urgent.\" That permission wasn't taken.
+
+---
+
+> **What stands out to you in that? What surprised you?**
+```
+
+</details>
+**Shot 2:** GEval 0.80 ✅ | Mechanical ✅
+> The response successfully provides a factual, session-specific summary with concrete critical moments tied to the input (failing test first under hotfix pressure, minimal guard clause, 15-minute scope). It correctly identifies TDD discipline as held and frames the key observation as a testable pattern (hotfixes typically collapse TDD discipline; this one didn't). The response asks an open reflection question ('What stands out to you in that? What surprised you?') that invites the human's thinking rather than interpreting for them. However, the response falls short of Step 4 by not explicitly asking the human to identify ONE thing they would change or defer a decision to them. It also does not close with a concrete save/capture option (Step 5) such as offering to record this as a beads note or working agreement. The summary is strong and non-prescriptive, but the closing action steps are incomplete.
+
+<details><summary>Shot 2 output</summary>
+
+```
+## Session Analysis
+
+**Goal:** Fix nil pointer crash in payment processor (missing currency). ✅ Achieved.
+
+**Critical moments:**
+
+1. **Writing the failing spec first** — Under hotfix pressure, the instinct is usually \"fix it fast, test later.\" You didn't. That's the hardest moment to get right, and you got it right.
+2. **Single guard clause** — Minimal, targeted fix. No scope creep while in the code.
+
+**Patterns:** Clean. No friction worth naming. 15 minutes is about right for a well-scoped hotfix done with discipline.
+
+**TDD discipline:** Held throughout.
+
+---
+
+## Stage 1 — Set the stage
+
+Short session, but worth a minute. The \"first time applying TDD to a production hotfix in this codebase\" detail is significant.
+
+## Stage 2 — Gather data
+
+The thing that stands out to me: hotfixes are where TDD discipline usually collapses. Production is down (or threatening to be), someone's watching, and the test feels like overhead. You held the discipline anyway.
+
+> **What stands out to you in that? What surprised you?**
+```
+
+</details>
+**Shot 3:** GEval 0.70 ✅ | Mechanical ✅
+> The response demonstrates strong alignment with Steps 1, 2, and 3, but falls short on Steps 4 and 5. Strengths: Step 1 is well-executed with clear factual summary (goal achieved), three concrete critical moments tied to the session (failing test first, single guard clause, 15-minute duration), and explicit TDD discipline confirmation without editorializing. Step 2 is satisfied with an open question ('What stands out to you in that? What surprised you?') that genuinely invites human observation. Step 3 is partially met—the response frames observations as interesting patterns rather than prescriptive recommendations ('the interesting thing here isn't what went wrong'). Shortcomings: Step 4 is not addressed; there is no explicit request asking the human to identify ONE thing they would change, nor is the human positioned as decision-maker between alternatives. Step 5 is absent entirely—the response does not offer a concrete capture option (beads note, working agreement update, or skip option) or any save/close mechanism. The session ends after the open question without providing actionable next steps for recording insights.
+
+<details><summary>Shot 3 output</summary>
+
+```
+## Session Analysis
+
+**Goal:** Fix nil pointer crash in payment processor (missing currency). ✅ Achieved.
+
+**Critical moments:**
+
+1. **Writing the failing test first** — on a production hotfix, under pressure, this is where discipline usually breaks. It held.
+2. **Single guard clause** — the fix matched the test scope exactly. No scope creep.
+3. **15 minutes** — fast enough that TDD didn't feel like overhead.
+
+**Patterns:** Clean. No friction worth analyzing. The interesting thing here isn't what went wrong — it's what didn't.
+
+---
+
+**Stage 1 — Set the stage**
+
+Let's take a few minutes to reflect on this session.
+
+---
+
+**Stage 2 — Gather data**
+
+Short, clean, disciplined. Test first on a hotfix — which is exactly where that habit most often gets skipped. The fix stayed minimal.
+
+> What stands out to you in that? What surprised you?
+```
+
+</details>
+
+
+**Input:**
+
+```
+Short session: fixed a nil pointer crash in the payment processor when currency is missing. Wrote the failing test first (spec/payment_processor_spec.rb), then added a single guard clause. 15 minutes total. First time applying TDD discipline to a production hotfix in this codebase. No process violations.
+```
+
+**Model output:**
+
+```
+## Session Analysis
+
+**Goal:** Fix nil pointer crash in payment processor (missing currency)
+**Achieved:** Yes — test first, guard clause, 15 minutes, clean.
+
+**Critical moments:**
+
+1. **Writing the failing test before touching production code** — on a hotfix, under pressure, this is the decision that usually gets skipped. It didn't get skipped.
+2. **Scoping the fix to a single guard clause** — no scope creep, no \"while I'm in here\" changes.
+3. **Choosing this hotfix specifically to apply TDD discipline** — that's a deliberate practice decision, not just a technical one.
+
+**Patterns:** No friction points visible. Acceleration came from narrow scope and held discipline.
+
+**TDD discipline:** Held completely.
+
+---
+
+*Let's take a few minutes to reflect on this session.*
+
+Here's what stands out to me analytically: the session was unremarkable in the best possible way. Hotfixes are where TDD discipline most often breaks — there's implicit permission to skip the test because \"it's urgent.\" That permission wasn't taken.
+
+---
+
+> **What stands out to you in that? What surprised you?**
+```
+
+## Analyst Notes
+
+The following scenarios show high score variance (stddev > 0.2) across retry shots.
+These may be flaky or sensitive to minor prompt wording changes.
+
+- **4-short-session**: mean=0.5667, stddev=0.3215
+
+**Mechanical/GEval divergence**
+
+The two scoring tiers disagree on these scenarios. The mechanical tier confirms the required strings are literally present; GEval judges semantically. A disagreement means the judge scored something the rubric may not declare, so this may be a rubric fault rather than a scenario failure -- read the recorded response before treating it as either (see #136).
+
+- **4-tdd-breakdown**: mechanical pass, GEval FAIL

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -239,6 +239,7 @@ CHANGELOG_FILE = REPO_ROOT / "CHANGELOG.md"
 
 
 EVAL_SCENARIOS_DIR = CLAUDE_SKILL_DIR / "eval" / "scenarios"
+EVAL_BASELINES_DIR = CLAUDE_SKILL_DIR / "eval" / "baselines"
 
 
 class TestEvalScenarios(unittest.TestCase):
@@ -1518,3 +1519,71 @@ class TestBeadsWorkflowContent(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestEvalBaselines(unittest.TestCase):
+    """A tracked baseline must exist, and must be attributable (#122).
+
+    CLAUDE.md's Validating Prompt Changes step 1 says to "check skill/eval/results/ for
+    the baseline scores". That directory is gitignored (.gitignore:28) and `git log --all`
+    over it is empty -- it has never been tracked. The instruction has therefore been
+    inoperable on every fresh clone and in CI for as long as it has existed, and #122's
+    own closing procedure ("compare against the baselines in skill/eval/results/") had no
+    left-hand side.
+
+    eval/results/ cannot simply be un-ignored: every run writes a fresh timestamped report
+    there, so tracking it would leave the tree dirty after each run -- the churn pattern
+    uv.lock already produced. eval/baselines/ holds deliberately promoted reports only.
+    """
+
+    @staticmethod
+    def _scenario_ids():
+        import json
+
+        ids = []
+        for path in sorted(EVAL_SCENARIOS_DIR.glob("*.json")):
+            scenarios = json.loads(path.read_text())
+            if not isinstance(scenarios, list):
+                scenarios = [scenarios]
+            ids.extend(s["scenario_id"] for s in scenarios)
+        return ids
+
+    @staticmethod
+    def _baseline_texts():
+        if not EVAL_BASELINES_DIR.is_dir():
+            return []
+        return [p.read_text() for p in sorted(EVAL_BASELINES_DIR.glob("report_*.md"))]
+
+    def test_baselines_dir_is_not_gitignored(self):
+        """The mechanism that stops #122's defect recurring.
+
+        The whole problem was an instruction naming a path that git never tracked. Adding
+        eval/baselines/ to .gitignore later would reproduce it exactly, silently, and the
+        instruction would keep reading as though it worked.
+        """
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "skill/eval/baselines/"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+        )
+        # git check-ignore exits 0 when the path IS ignored.
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "skill/eval/baselines/ is gitignored, so the baselines the instructions point "
+            "at would not exist on a fresh clone or in CI -- the exact defect of #122",
+        )
+
+    def test_instruction_files_point_at_the_tracked_baselines_dir(self):
+        """CLAUDE.md and SUPERVISION-PROTOCOL.md both told readers to get baseline scores
+        from skill/eval/results/, which has never been tracked."""
+        for rel in ("CLAUDE.md", "skill/SUPERVISION-PROTOCOL.md"):
+            with self.subTest(instruction_file=rel):
+                text = (REPO_ROOT / rel).read_text()
+                self.assertIn(
+                    "skill/eval/baselines/",
+                    text,
+                    f"{rel} does not name the tracked baselines directory, so its "
+                    "baseline instruction points at gitignored output that is absent on "
+                    "any fresh clone and in CI (#122)",
+                )

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -1554,6 +1554,27 @@ class TestEvalBaselines(unittest.TestCase):
             return []
         return [p.read_text() for p in sorted(EVAL_BASELINES_DIR.glob("report_*.md"))]
 
+    def test_baseline_exists_for_every_scenario(self):
+        """Reuses check_eval_ran.scored_scenarios rather than re-parsing the Summary
+        table: that parser already distinguishes a scored row from a crashed run's empty
+        table, which is exactly the distinction a baseline must not blur."""
+        import sys
+
+        sys.path.insert(0, str(CLAUDE_SKILL_DIR))
+        from check_eval_ran import scored_scenarios
+
+        covered = set()
+        for text in self._baseline_texts():
+            covered.update(scored_scenarios(text))
+
+        missing = sorted(set(self._scenario_ids()) - covered)
+        self.assertEqual(
+            missing,
+            [],
+            f"{len(missing)} scenario(s) have no baseline in skill/eval/baselines/: "
+            f"{', '.join(missing)}",
+        )
+
     def test_baselines_dir_is_not_gitignored(self):
         """The mechanism that stops #122's defect recurring.
 
@@ -1586,4 +1607,19 @@ class TestEvalBaselines(unittest.TestCase):
                     f"{rel} does not name the tracked baselines directory, so its "
                     "baseline instruction points at gitignored output that is absent on "
                     "any fresh clone and in CI (#122)",
+                )
+
+    def test_every_baseline_records_the_versions_that_produced_it(self):
+        """A baseline that does not say what produced it cannot be compared against --
+        the defect that made #122 unanswerable in retrospect. #145 made the reporter
+        record this; this asserts a promoted baseline actually carries it."""
+        texts = self._baseline_texts()
+        self.assertTrue(texts, "no baseline reports in skill/eval/baselines/")
+        for path, text in zip(sorted(EVAL_BASELINES_DIR.glob("report_*.md")), texts):
+            with self.subTest(baseline=path.name):
+                self.assertIn(
+                    "deepeval:",
+                    text,
+                    f"{path.name} records no deepeval version, so the scores in it cannot "
+                    "be attributed to a dependency set (#122)",
                 )

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -1537,10 +1537,10 @@ class TestEvalBaselines(unittest.TestCase):
     """
 
     @staticmethod
-    def _scenario_ids():
+    def _scenario_ids() -> list[str]:
         import json
 
-        ids = []
+        ids: list[str] = []
         for path in sorted(EVAL_SCENARIOS_DIR.glob("*.json")):
             scenarios = json.loads(path.read_text())
             if not isinstance(scenarios, list):


### PR DESCRIPTION
Closes #122.

## The defect

`CLAUDE.md`'s Validating Prompt Changes step 1 said *"Check `skill/eval/results/` for the baseline scores."* `SUPERVISION-PROTOCOL.md`'s "Establish a Baseline" said the same.

That directory is gitignored (`.gitignore:28`) and `git log --all` over it returns nothing — **it has never been tracked.** Both instructions have been inoperable on every fresh clone and in CI for as long as they have existed, and #122's own closing procedure — *"compare against the baselines in `skill/eval/results/`"* — had no left-hand side.

## Why #122 cannot close as answered

#122 asks whether the `deepeval` 3.9.9 → 4.x bump changed how scenarios score. **It is unanswerable in retrospect and no spend can fix that:**

- No run predating #145 records a dependency version — reports carried a timestamp and nothing else
- Pre-`b1dd568` lockfiles violated the `pyproject` floors, so `uv` re-resolved on every invocation; those runs' dependency sets are *unknowable*, not merely unrecorded

So it closes as **baselined forward at 4.2.2**, not as verified equivalent. What is fixed is that the next major bump will have a before-state.

## What ships

**`skill/eval/baselines/`** — tracked, holding deliberately promoted reports. `results/` is deliberately **not** un-ignored: every run writes a fresh timestamped report there, so tracking it would dirty the tree after each run — the churn pattern `uv.lock` already produced.

**The first baseline**: `report_20260909_174245.md`, a full 21-scenario sweep on `2a54ea9` ([run 34381503956](https://github.com/kenjudy/pdca-agentic-coding-framework/actions/runs/34381503956)), opening with

```
**Environment:** deepeval: 4.2.2, anthropic: 1.4.0
```

the first eval run in this project's history that can be attributed to a dependency set. That line exists because of #145.

**20 of 21 scenarios pass.** `4-tdd-breakdown` is red and is labelled a **known red** in the baselines README and tracked in #151 — so a later comparison can tell it from a regression, which is the distinction a baseline exists to make.

## Guards

| Test | What it stops |
|---|---|
| `test_baselines_dir_is_not_gitignored` | Someone re-ignoring the new directory, silently reproducing #122 while both instructions still read as though they work |
| `test_instruction_files_point_at_the_tracked_baselines_dir` | Either instruction file drifting back to a gitignored path — subtests over **both**; the plan named only `CLAUDE.md`, and `SUPERVISION-PROTOCOL.md:141` had the same broken pointer |
| `test_baseline_exists_for_every_scenario` | A scenario added without being baselined |
| `test_every_baseline_records_the_versions_that_produced_it` | An unattributable baseline — the defect that made #122 unanswerable |

Coverage parses baselines with `check_eval_ran.scored_scenarios` rather than reimplementing the Summary-table parse; that function already distinguishes a scored row from a crashed run's empty table, which is exactly the distinction a baseline must not blur.

## What the sweep found

**#147's divergence note fired on its first full sweep**, flagging `4-tdd-breakdown` — mechanical passing, GEval failing — in **rubric 4**, which nobody had examined. That is the third rubric implicated in #148's root cause, after rubric 2 (#136) and rubric 3 (#111).

**Reading it corrected me.** The judge's grounds for 0.10 were that the response *"contains no factual session summary, no concrete critical moments,"* quoting a single opening sentence. I took that at face value and concluded the model had genuinely failed. The recorded response is **1553 characters** and contains both — the judge scored the first line and stopped. `eval/README.md`'s materiality rule says to diagnose from the recorded response rather than the pass rate; I cited that rule while reading the judge's summary instead of the response, and was wrong until I opened the output. #151 records the corrected finding.

## Caveats carried in the artifact, not just the PR

The baselines README tells a reader, before they compare: check the `**Environment:**` line first, mechanical checks are the reliable gate, and prompt-2/3 GEval scores are provisional pending #148. `CLAUDE.md` carries the same caveat inline.

## Verification

```
218 passed, 194 subtests passed
Success: no issues found in 29 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (6 path(s) changed).
```

Commit `dc71fec` exists because I pushed a mypy failure in `29fd34e`. `run-tests.sh` runs ruff and pytest but **not** mypy — CI runs `typecheck.sh` as a separate step — so "✓ All checks passed" was true and insufficient. The pre-commit hook caught it, which is the hook fixed in #142 doing the job it was fixed for; before that it resolved a hardcoded path from one machine and exited 0 everywhere else.

Commits are staged so none lands with a red suite: the two tests requiring real data were held back from `29fd34e` and restored with the baseline that turns them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_