### PR TITLE
Pool eval verdicts across runs — does a scenario change verdict between runs?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,23 @@
   obvious abuse — a scenario with GEval off and no mechanical signal cannot fail, and would
   report as a pass forever.
 
+- **Verdicts can now be pooled across runs (#147 deliverable 2).** `eval/aggregate.py` reads
+  several reports and names the scenarios whose **verdict changed** between them — the question
+  that decides whether a scenario is usable as a regression gate, and one no single run can
+  answer. Analyst Notes sees variance within one run; the divergence note sees the two tiers
+  disagreeing in one run; neither could see a scenario passing on Monday and failing on Tuesday.
+  The reporter cannot either: its fixture is `scope="session"`, so each `run-evals.sh`
+  invocation writes its own file, and `evals.yml`'s multi-shot dispatch was producing exactly
+  this data and dropping it.
+- **It reports no cause, deliberately.** #147 as filed proposed flagging bimodal scores as
+  "judge instability"; that was corrected, because every rubric's bands are `1.0/0.7/0.4/0.0`
+  against a `0.50` threshold (#153), so a gap at the threshold is partly structural and a shape
+  alone cannot separate an unstable judge from an unstable model. Naming a cause would be #141's
+  defect one level up — output that reads like a measurement. It refuses to run on a single
+  report for the same reason: "stable" is not a conclusion one observation supports.
+- Verified against the two real full sweeps to date, where it independently reproduced the one
+  verdict flip previously found by hand: `2-first-step`, 1 pass / 1 fail, scores 0.30–0.70.
+
 - **CI now collects `tests/test_evals.py` without running it.** That file is excluded from the
   default suite because it makes real API calls, so a broken import there was previously only
   discoverable by paying for an eval run. It also cannot be imported without a credential — it

--- a/skill/eval/README.md
+++ b/skill/eval/README.md
@@ -37,7 +37,7 @@ apply the correct one based on the scenario input. This mirrors real skill usage
 cd skill
 uv sync --extra eval
 cp .env.example .env        # fill in ANTHROPIC_API_KEY
-bash run-evals.sh           # all 15 scenarios
+bash run-evals.sh           # all 21 scenarios
 ```
 
 Run a single prompt's tests:
@@ -57,6 +57,31 @@ Unit tests (no API calls, always run in CI):
 ```bash
 bash run-tests.sh
 ```
+
+### Pooling verdicts across runs
+
+A single run cannot tell you whether a scenario is a usable gate. `eval/aggregate.py`
+pools several reports and names the scenarios whose **verdict changed** between them:
+
+```bash
+uv run python eval/aggregate.py eval/results/            # your local runs
+uv run python eval/aggregate.py eval/baselines/ eval/results/
+```
+
+```
+## Verdict changed across runs
+
+- **2-first-step**: 1 pass / 1 fail over 2 run(s), scores 0.30–0.70, tiers disagreed in 1 of 2
+```
+
+It needs at least two reports and refuses to run on one, because "stable" is not a
+conclusion a single observation supports.
+
+It deliberately reports **no cause**. A scenario that changes verdict may have an unstable
+judge or an unstable model, and the scoring bands (`1.0/0.7/0.4/0.0` against a `0.50`
+threshold) push borderline scores away from the middle regardless — so the shape alone
+cannot separate the two. Use it to find which recorded responses are worth reading, then
+apply the materiality rule below.
 
 ---
 

--- a/skill/eval/aggregate.py
+++ b/skill/eval/aggregate.py
@@ -1,0 +1,221 @@
+"""Pool eval verdicts across runs (#147 deliverable 2).
+
+`EvalReporter`'s Analyst Notes flag high variance within one run, and #147's divergence
+note flags the two scoring tiers disagreeing. Neither can answer the question that
+actually decides whether a scenario is usable as a regression gate: **does its verdict
+change from run to run?**
+
+That question needs several reports, and the reporter cannot see them. Its fixture is
+`scope="session"`, so each `run-evals.sh` invocation writes its own file holding at most
+3 retry-shots for a scenario. The bimodal distribution that diagnosed #136 was visible
+only across ten separate reports, and nothing in the project reads them back --
+`evals.yml`'s multi-shot dispatch produces exactly that data and then drops it.
+
+WHAT THIS DELIBERATELY DOES NOT DO: attribute a cause. #147 as filed proposed flagging
+bimodal scores as "judge instability". That was corrected -- the scoring bands are
+1.0/0.7/0.4/0.0 against a 0.50 threshold in every rubric (#153), so a gap at the
+threshold is partly structural and a shape alone cannot separate an unstable judge from
+an unstable model. Naming a cause here would be #141's defect one level up: output that
+reads like a measurement. This reports what happened and points at the scenarios worth
+reading.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SUMMARY_HEADING = "## Summary"
+SEPARATOR_PREFIX = "|---"
+DETAILS_HEADING = "## Scenario Details"
+
+# "**Shot 2:** GEval 0.90 ✅ | Mechanical ✅"
+SHOT_RE = re.compile(r"\*\*Shot \d+:\*\*\s*GEval\s+([\d.]+)")
+# "### 4-short-session (Retrospection)"
+DETAIL_HEAD_RE = re.compile(r"^###\s+(\S+)")
+
+
+@dataclass
+class ScenarioRun:
+    """One scenario's result in one report."""
+
+    geval_passed: bool
+    mechanical_passed: bool
+    scores: list[float] = field(default_factory=list)
+
+
+@dataclass
+class ScenarioAggregate:
+    """One scenario pooled across reports."""
+
+    runs: int = 0
+    passes: int = 0
+    fails: int = 0
+    divergent_runs: int = 0
+    scores: list[float] = field(default_factory=list)
+
+    @property
+    def verdict_unstable(self) -> bool:
+        """Both outcomes were observed. A fact, not a diagnosis -- but a scenario that
+        does this cannot serve as a gate, whatever the cause."""
+        return self.passes > 0 and self.fails > 0
+
+
+def _shots_by_scenario(text: str) -> dict[str, list[float]]:
+    """Per-shot GEval scores from the Scenario Details section, keyed by scenario."""
+    if DETAILS_HEADING not in text:
+        return {}
+    shots: dict[str, list[float]] = {}
+    current: str | None = None
+    for line in text[text.index(DETAILS_HEADING):].splitlines():
+        head = DETAIL_HEAD_RE.match(line.strip())
+        if head:
+            current = head.group(1)
+            continue
+        if current is None:
+            continue
+        found = SHOT_RE.search(line)
+        if found:
+            shots.setdefault(current, []).append(float(found.group(1)))
+    return shots
+
+
+def parse_report(text: str) -> dict[str, ScenarioRun]:
+    """Scenario results from one rendered report.
+
+    Verdicts come from the Summary table, which states them unambiguously. Scores come
+    from the individual shots where a scenario was retried -- a retried row renders
+    "mean ± stddev", which is not a score anyone observed. A skipped GEval renders "n/a"
+    and contributes no score at all; treating that as 0.0 would invent a measurement.
+    """
+    if SUMMARY_HEADING not in text:
+        return {}
+
+    shots = _shots_by_scenario(text)
+    results: dict[str, ScenarioRun] = {}
+    past_separator = False
+
+    for line in text[text.index(SUMMARY_HEADING):].splitlines():
+        stripped = line.strip()
+        if stripped.startswith(SEPARATOR_PREFIX):
+            past_separator = True
+            continue
+        if not past_separator:
+            continue
+        if not stripped.startswith("|"):
+            break
+
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) < 6 or not cells[0]:
+            continue
+        scenario, _, score_cell, _, geval, mechanical = cells[:6]
+
+        scores = shots.get(scenario, [])
+        if not scores:
+            single = re.fullmatch(r"[\d.]+", score_cell)
+            if single:
+                scores = [float(score_cell)]
+
+        results[scenario] = ScenarioRun(
+            geval_passed="✅" in geval,
+            mechanical_passed="✅" in mechanical,
+            scores=scores,
+        )
+    return results
+
+
+def aggregate_reports(report_texts: list[str]) -> dict[str, ScenarioAggregate]:
+    """Pool scenario results across reports.
+
+    Requires more than one report. A single run cannot show instability, and reporting
+    "stable" from one observation is the claim CLAUDE.md explicitly warns against: "A
+    single eval run cannot tell you whether your prompt edit caused a failure."
+    """
+    if len(report_texts) < 2:
+        raise ValueError(
+            "aggregation needs at least two reports -- a single run cannot show whether a "
+            "verdict is stable, and calling it stable from one observation is exactly the "
+            "inference CLAUDE.md warns against"
+        )
+
+    pooled: dict[str, ScenarioAggregate] = {}
+    for text in report_texts:
+        for scenario, run in parse_report(text).items():
+            agg = pooled.setdefault(scenario, ScenarioAggregate())
+            agg.runs += 1
+            if run.geval_passed:
+                agg.passes += 1
+            else:
+                agg.fails += 1
+            if run.geval_passed != run.mechanical_passed:
+                agg.divergent_runs += 1
+            agg.scores.extend(run.scores)
+    return pooled
+
+
+def format_summary(pooled: dict[str, ScenarioAggregate]) -> str:
+    """Render the pooled result.
+
+    States what was observed and where to look. Says nothing about why -- see the module
+    docstring.
+    """
+    lines = ["# Cross-run verdict stability", ""]
+    lines.append(f"Scenarios pooled: {len(pooled)}")
+    lines.append("")
+
+    unstable = {s: a for s, a in sorted(pooled.items()) if a.verdict_unstable}
+    if not unstable:
+        lines.append("No scenario changed verdict across the reports supplied.")
+    else:
+        lines.append("## Verdict changed across runs")
+        lines.append("")
+        lines.append(
+            "These scenarios both passed and failed. Whatever the cause, a scenario that "
+            "does this cannot serve as a regression gate -- read the recorded responses "
+            "in the reports before treating any single run of it as a result."
+        )
+        lines.append("")
+        for scenario, agg in unstable.items():
+            spread = ""
+            if agg.scores:
+                spread = f", scores {min(agg.scores):.2f}–{max(agg.scores):.2f}"
+            diverged = (
+                f", tiers disagreed in {agg.divergent_runs} of {agg.runs}"
+                if agg.divergent_runs
+                else ""
+            )
+            lines.append(
+                f"- **{scenario}**: {agg.passes} pass / {agg.fails} fail "
+                f"over {agg.runs} run(s){spread}{diverged}"
+            )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(f"usage: python {Path(__file__).name} <report.md|dir> [...]", file=sys.stderr)
+        return 2
+
+    texts: list[str] = []
+    for arg in argv:
+        path = Path(arg)
+        files = sorted(path.glob("*.md")) if path.is_dir() else [path]
+        texts.extend(f.read_text() for f in files if f.is_file())
+
+    if len(texts) < 2:
+        print(
+            f"Found {len(texts)} report(s). Aggregation needs at least two -- a single run "
+            "cannot show whether a verdict is stable.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(format_summary(aggregate_reports(texts)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/skill/tests/test_aggregate.py
+++ b/skill/tests/test_aggregate.py
@@ -1,0 +1,120 @@
+"""Unit tests for eval.aggregate — pooling verdicts across runs (#147 deliverable 2)."""
+
+import textwrap
+
+import pytest
+
+from eval.aggregate import aggregate_reports, format_summary, parse_report
+
+
+def _report(rows, details=""):
+    """A minimal report in EvalReporter's rendered shape."""
+    head = textwrap.dedent("""\
+        # PDCA Eval Report — 2026-09-10 12:00:00
+
+        **Environment:** deepeval: 4.2.2, anthropic: 1.4.0
+
+        ## Summary
+
+        | Scenario | Phase | Score | Threshold | GEval | Mechanical |
+        |----------|-------|-------|-----------|-------|------------|
+        """)
+    return head + "\n".join(rows) + "\n\n## Scenario Details\n" + details
+
+
+class TestParseReport:
+    def test_reads_verdicts_and_score_from_the_summary(self):
+        parsed = parse_report(_report(["| 2-first-step | TDD | 0.70 | 0.50 | ✅ | ✅ |"]))
+        run = parsed["2-first-step"]
+        assert run.geval_passed is True
+        assert run.mechanical_passed is True
+        assert run.scores == [0.70]
+
+    def test_reads_individual_shots_when_a_scenario_was_retried(self):
+        """A retried row shows 'mean ± stddev', which is not a score anyone observed. The
+        shots are the measurements and the distribution has to be built from them."""
+        details = textwrap.dedent("""\
+            ### 4-short-session (Retrospection)
+
+            **Shot 1:** GEval 0.20 ❌ | Mechanical ✅
+            **Shot 2:** GEval 0.90 ✅ | Mechanical ✅
+            **Shot 3:** GEval 0.60 ✅ | Mechanical ✅
+            """)
+        parsed = parse_report(
+            _report(["| 4-short-session | Retrospection | 0.5667 ± 0.3215 | 0.50 | ✅ | ✅ |"], details)
+        )
+        assert parsed["4-short-session"].scores == [0.20, 0.90, 0.60]
+
+    def test_skipped_geval_contributes_no_score(self):
+        """skip_geval renders 'n/a'. Treating that as 0.0 would invent a measurement."""
+        parsed = parse_report(
+            _report(["| 2-skip-tests-request | TDD | n/a | 0.00 | ✅ | ✅ |"])
+        )
+        assert parsed["2-skip-tests-request"].scores == []
+
+
+class TestAggregate:
+    def test_verdict_is_stable_when_every_run_agrees(self):
+        reports = [_report(["| s | TDD | 0.90 | 0.50 | ✅ | ✅ |"]) for _ in range(3)]
+        agg = aggregate_reports(reports)["s"]
+        assert agg.runs == 3
+        assert agg.verdict_unstable is False
+
+    def test_verdict_is_unstable_when_a_scenario_both_passed_and_failed(self):
+        """The actionable fact, and not an inference: a scenario that changes verdict
+        across runs cannot serve as a regression gate, whatever the cause. #111 and #136
+        are both instances, and both took a human reading responses to establish."""
+        reports = [
+            _report(["| s | TDD | 0.90 | 0.50 | ✅ | ✅ |"]),
+            _report(["| s | TDD | 0.30 | 0.50 | ❌ | ✅ |"]),
+        ]
+        agg = aggregate_reports(reports)["s"]
+        assert agg.verdict_unstable is True
+
+    def test_counts_runs_where_the_two_tiers_disagreed(self):
+        reports = [
+            _report(["| s | TDD | 0.30 | 0.50 | ❌ | ✅ |"]),
+            _report(["| s | TDD | 0.90 | 0.50 | ✅ | ✅ |"]),
+        ]
+        assert aggregate_reports(reports)["s"].divergent_runs == 1
+
+    def test_pools_scores_across_reports(self):
+        reports = [
+            _report(["| s | TDD | 0.90 | 0.50 | ✅ | ✅ |"]),
+            _report(["| s | TDD | 0.30 | 0.50 | ❌ | ✅ |"]),
+        ]
+        assert sorted(aggregate_reports(reports)["s"].scores) == [0.30, 0.90]
+
+
+class TestFormatSummary:
+    def test_names_unstable_scenarios(self):
+        reports = [
+            _report(["| flaky | TDD | 0.90 | 0.50 | ✅ | ✅ |"]),
+            _report(["| flaky | TDD | 0.30 | 0.50 | ❌ | ✅ |"]),
+        ]
+        out = format_summary(aggregate_reports(reports))
+        assert "flaky" in out
+        assert "1 pass / 1 fail" in out
+
+    def test_does_not_attribute_a_cause(self):
+        """#147, corrected: the band ladder produces a gap at the threshold structurally
+        (#153), so a shape alone cannot distinguish an unstable judge from an unstable
+        model. Reporting either as a conclusion would be #141's defect one level up --
+        output that reads like a measurement."""
+        reports = [
+            _report(["| flaky | TDD | 0.90 | 0.50 | ✅ | ✅ |"]),
+            _report(["| flaky | TDD | 0.30 | 0.50 | ❌ | ✅ |"]),
+        ]
+        out = format_summary(aggregate_reports(reports)).lower()
+        for verdict_word in ("judge instability", "rubric fault", "model is flaky"):
+            assert verdict_word not in out
+
+    def test_reports_nothing_to_flag_when_everything_is_stable(self):
+        reports = [_report(["| s | TDD | 0.90 | 0.50 | ✅ | ✅ |"]) for _ in range(3)]
+        assert "no scenario changed verdict" in format_summary(aggregate_reports(reports)).lower()
+
+    def test_requires_more_than_one_report(self):
+        """One run cannot show instability, and saying 'stable' from a single observation
+        is exactly the claim CLAUDE.md warns against."""
+        with pytest.raises(ValueError):
+            aggregate_reports([_report(["| s | TDD | 0.90 | 0.50 | ✅ | ✅ |"])])


### PR DESCRIPTION
Closes #147 (deliverable 2; deliverable 1 shipped in #150).

## The gap

Three mechanisms look at eval output. Each sees something the others cannot, and none could answer the question that decides whether a scenario is usable as a gate:

| | scope |
|---|---|
| Analyst Notes | variance **within** one run (`stddev > 0.2`) |
| Divergence note (#150) | the two scoring tiers disagreeing **in** one run |
| **`eval/aggregate.py`** | does the verdict change **between** runs |

The reporter cannot see across runs by construction: `tests/test_evals.py`'s `reporter` fixture is `scope="session"`, so each `run-evals.sh` invocation writes its own file holding at most 3 retry-shots for a scenario. `evals.yml`'s multi-shot dispatch has been producing exactly this data and dropping it — the distribution that diagnosed #136 was only visible because ten reports were read by hand.

## Verdict instability, not bimodality

#147 as filed proposed flagging bimodal scores as **"judge instability."** Its own correction refutes that: every rubric scores `1.0 / 0.7 / 0.4 / 0.0` against a `0.50` threshold (#153), so a gap at the threshold is **partly structural**, and a shape alone cannot separate an unstable judge from an unstable model.

So the primitive is *"this scenario both passed and failed"* — a fact requiring no inference, and precisely what #111 and #136 were complaining about. The pooled score range still prints so a reader can see the shape and judge cause themselves.

**It reports no cause anywhere**, asserted by `test_does_not_attribute_a_cause`. Naming one would be #141's defect one level up: output that reads like a measurement.

**It refuses to run on fewer than two reports.** "Stable" is not a conclusion one observation supports — `CLAUDE.md`: *"A single eval run cannot tell you whether your prompt edit caused a failure."*

## Verified against real data, not just fixtures

Run against the only two full sweeps that exist — the tracked baseline from #152 and the parked band-gap sweep from #153 — it independently reproduced the single verdict flip I had previously found by hand comparison:

```
## Verdict changed across runs

- **2-first-step**: 1 pass / 1 fail over 2 run(s), scores 0.30–0.70, tiers disagreed in 1 of 2
```

and correctly left `4-tdd-breakdown` alone, which failed **stably** in both — a scenario that is reliably red is not unstable, and flagging it would have been noise.

## Two parsing decisions worth stating

- **A retried row renders `mean ± stddev`**, which is not a score anyone observed. Scores come from the individual `**Shot N:**` lines where they exist.
- **`skip_geval` renders `n/a` and contributes no score.** Reading it as `0.0` would invent a measurement — the failure this repo keeps finding in other forms.

## Testing

**RED first:** `ModuleNotFoundError: No module named 'eval.aggregate'`, then 11 assertions.

New test file rather than appending to an existing one — appending has caused four separate "red for the wrong reason" import misses in this line of work, where a test failed on `NameError` instead of the called shot.

## Verification

```
233 passed, 209 subtests passed
Success: no issues found in 32 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (4 path(s) changed).
```

mypy earned its place here: it caught a leftover `["| x | y | z |"] and _report(...)` in one of my tests, which evaluated to the right thing and was nonsense.

Also fixes stale documentation — `eval/README.md` said "all 15 scenarios"; there are 21.

## What this unblocks

#148's comment recommends establishing how widespread rubric mis-scoring actually is **before** anyone attempts the rubric tail rewrite, since that means rewriting all five rubrics' scaffolds. This is the instrument for that: run it over a directory of accumulated reports and see how many scenarios are genuinely unstable, rather than inferring from the two or three that happened to get read.

## Related

- #147 — this issue; deliverable 1 was #150
- #153 — why "gap at the threshold" is not by itself diagnostic
- #111, #136, #151 — the scenarios this exists to identify mechanically
- #141 — a broken mechanism reporting a number that looks like a measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_