### PR TITLE
Build the GEval judge lazily so the eval suite can be imported without a key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,13 +94,10 @@ jobs:
       # calls, so a broken import or a bad node id there is otherwise only discoverable by
       # dispatching an eval run -- half an hour and a few dollars to learn that a module
       # does not import. --collect-only imports and enumerates without executing anything.
+      # Runs with NO key at all, deliberately. The judge is constructed lazily (#156), so
+      # importing the module needs no credential -- and running this without one is what
+      # proves it stays that way. A dummy key here would let module-scope construction
+      # return unnoticed, since the step would keep passing.
       - name: Collect the eval suite without running it
-        env:
-          # It builds AnthropicModel at MODULE IMPORT time, so the file cannot be imported
-          # at all without a key -- deepeval raises during construction. Collection makes no
-          # API calls, so an obviously-fake key suffices, mirroring what
-          # tests/test_eval_imports.py already does. If this ever needs a REAL key the step
-          # has stopped being free and should be reconsidered, not handed the secret.
-          ANTHROPIC_API_KEY: sk-ant-dummy-key-for-collection-only
         run: uv run --locked python -m pytest --collect-only tests/test_evals.py -q
         working-directory: skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,21 @@
   obvious abuse — a scenario with GEval off and no mechanical signal cannot fail, and would
   report as a pass forever.
 
+- **`tests/test_evals.py` no longer needs an API key to import (#156).** It built
+  `AnthropicModel` at module scope, and deepeval raises during construction when no key is
+  configured — so the file could not be imported, collected, or meaningfully type-checked
+  without a credential. That is why it slipped past every cheap check the project has, and why
+  every edit to it has been unverifiable except by dispatching a paid eval run. The judge is
+  now built on first use, cached, so it is still constructed exactly once per session at the
+  point an API call is about to happen — mirroring `eval/executor.py`'s `_client()`, which
+  defers construction for the same reason.
+- **The CI collection step now runs with no key at all**, which is what proves the property
+  holds. It previously passed a dummy key as a workaround; leaving that in place would have let
+  module-scope construction return unnoticed, since the step would have kept passing.
+  `test_judge_model_is_not_constructed_at_module_scope` checks the source by parsing it rather
+  than importing it — importing is the thing that did not work, and the guard has to run in the
+  default suite, which installs neither deepeval nor a key.
+
 - **Verdicts can now be pooled across runs (#147 deliverable 2).** `eval/aggregate.py` reads
   several reports and names the scenarios whose **verdict changed** between them — the question
   that decides whether a scenario is usable as a regression gate, and one no single run can

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -1013,6 +1013,59 @@ class TestHookInfrastructure(unittest.TestCase):
             "fail on a missing deepeval rather than testing anything",
         )
 
+    def test_judge_model_is_not_constructed_at_module_scope(self):
+        """tests/test_evals.py must be importable without a credential (#156).
+
+        deepeval raises during AnthropicModel construction when no key is present, so a
+        module-scope judge makes the file unimportable, uncollectable, and unanalysable
+        without a secret -- which is why every cheap check has skipped it and why every
+        edit to it has been unverifiable except by paying for an eval run.
+
+        Checked by parsing the source rather than importing it. Importing is the thing
+        that does not work, and this test has to run in the default suite, which installs
+        neither deepeval nor a key.
+        """
+        import ast
+
+        source = (CLAUDE_SKILL_DIR / "tests" / "test_evals.py").read_text()
+        offenders = []
+        for node in ast.parse(source).body:
+            # A function body runs when called, not when the module is imported, so a
+            # construction inside one is the fix rather than the defect.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                func = call.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name == "AnthropicModel":
+                    offenders.append(getattr(node, "lineno", "?"))
+        self.assertEqual(
+            offenders,
+            [],
+            f"tests/test_evals.py constructs AnthropicModel at module scope (line(s) "
+            f"{offenders}), so importing the module requires an API key",
+        )
+
+    def test_eval_collection_needs_no_api_key(self):
+        """The observable consequence of the fix, and the reason to make it.
+
+        The collection step shipped with a dummy key because the module could not be
+        imported without one. Once the judge is built lazily that workaround is dead
+        weight, and leaving it would hide a regression: if module-scope construction came
+        back, the step would keep passing on the dummy key and say nothing.
+        """
+        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text()
+        step = workflow[workflow.index("Collect the eval suite without running it"):]
+        step = step[: step.index("--collect-only")]
+        self.assertNotIn(
+            "ANTHROPIC_API_KEY",
+            step,
+            "the eval-collection step still sets ANTHROPIC_API_KEY, so it cannot detect a "
+            "return to module-scope judge construction -- it would pass on the dummy key",
+        )
+
     def test_ci_collects_the_eval_suite(self):
         """Something must import tests/test_evals.py without spending money.
 

--- a/skill/tests/test_evals.py
+++ b/skill/tests/test_evals.py
@@ -35,7 +35,27 @@ from eval.rubrics.rubric_3 import THRESHOLD as THRESHOLD_3
 from eval.rubrics.rubric_4 import CRITERIA as CRITERIA_4
 from eval.rubrics.rubric_4 import THRESHOLD as THRESHOLD_4
 
-JUDGE_MODEL = AnthropicModel(model="claude-haiku-4-5-20251001")
+JUDGE_MODEL_NAME = "claude-haiku-4-5-20251001"
+
+_judge_model: AnthropicModel | None = None
+
+
+def judge_model() -> AnthropicModel:
+    """The GEval judge, built on first use rather than at import (#156).
+
+    deepeval raises during AnthropicModel construction when no key is configured, so
+    building this at module scope made the file unimportable without a credential --
+    and therefore uncollectable, unanalysable, and unverifiable except by dispatching a
+    paid eval run. Every cheap check the project has skipped this file for that reason.
+
+    Mirrors eval/executor.py's `_client()`, which defers construction for the same
+    reason. Cached, so the model is still built exactly once per session, at the point
+    where an API call is actually about to happen.
+    """
+    global _judge_model
+    if _judge_model is None:
+        _judge_model = AnthropicModel(model=JUDGE_MODEL_NAME)
+    return _judge_model
 
 pytestmark = pytest.mark.eval
 
@@ -98,7 +118,7 @@ def _run_scenario(scenario: dict, include_skill_prompt: bool = True) -> dict:
         criteria=criteria,
         evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT],
         threshold=threshold,
-        model=JUDGE_MODEL,
+        model=judge_model(),
     )
     test_case = LLMTestCase(input=scenario["input"], actual_output=output)
     metric.measure(test_case)


### PR DESCRIPTION
Closes #156.

## The defect

`tests/test_evals.py:38` constructed the judge at module scope:

```python
JUDGE_MODEL = AnthropicModel(model="claude-haiku-4-5-20251001")
```

deepeval raises during construction when no key is configured, so **importing the module at all required a credential**:

```
DeepEvalError: Anthropic API key is not configured.
```

## Why this mattered more than one line suggests

It is why this file slipped past every cheap check the project has:

| check | why it skipped `test_evals.py` |
|---|---|
| default unit suite | excluded by `addopts` — it makes real API calls |
| `eval-imports` job | imports `test_eval_imports.py`, not this |
| `--collect-only` | could not import the module without a key |
| `mypy` | a module that cannot be imported gets no meaningful analysis |

So **every edit to this file has been unverifiable except by dispatching a paid eval run** — half an hour and a few dollars to learn whether a module imports. #154 rewired its rubric lookup with no way to check it locally.

## The fix

The judge is built on first use and cached, so it is still constructed exactly once per session, at the point an API call is actually about to happen.

This mirrors `eval/executor.py`'s `_client()`, which defers construction for the same reason and says so in its docstring. An existing convention this file simply did not follow — not a new pattern.

## The CI step now runs with **no key at all**

It shipped with a dummy key in #154 because the module could not be imported without one. Removing that is the point, not tidying: a dummy key would let module-scope construction return unnoticed, because the step would keep passing on it.

## Two guards, both runnable in the default suite

- **`test_judge_model_is_not_constructed_at_module_scope`** parses the source with `ast` rather than importing it. Importing is the thing that did not work, and the guard has to run where neither deepeval nor a key is installed.
- **`test_eval_collection_needs_no_api_key`** asserts the workflow step sets no `ANTHROPIC_API_KEY`.

## Testing

**RED first:** `AssertionError: Lists differ: [38] != []` — line 38, the construction.

**Then I got the guard wrong and loosened it to pass**, which is the move that needs proving rather than asserting. The first version walked every top-level node including function bodies, so it flagged the lazy accessor itself — the fix, not the defect. A function body runs when called, not at import, so `FunctionDef` is skipped.

**Mutation-tested afterwards** to confirm the loosening did not blunt it: reintroducing `JUDGE_MODEL = AnthropicModel(...)` fails the corrected guard at the exact line.

## What is *not* verified here

**Collection succeeding is not proof that execution still scores.** The judge now lives inside a function that only the GEval path calls, and nothing in this PR exercises that path — the file remains excluded from the default suite for the good reason that it spends money.

A single-scenario dispatch is running against this branch to confirm the harness still scores end to end. I will post the result on this PR. Merging on green CI alone would be trusting exactly the kind of green this repository distrusts: a check that passes because the expensive part never ran.

## Verification

```
235 passed, 209 subtests passed
Success: no issues found in 32 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (4 path(s) changed).
```

## Related

- #156 — this issue
- #154 — added the collection step and its dummy-key workaround, now removed
- #122 — the original "no test imports these packages" finding
- #142 — a gate that looked like coverage and could not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_