### PR TITLE
Called shot must predict the first-executing assertion, not the most meaningful one

### DIFF
--- a/2. Do/2. Test Drive the Change.md
+++ b/2. Do/2. Test Drive the Change.md
@@ -41,11 +41,11 @@ Try to add tests to existing fixtures where the tests fit coherently into the co
 YOU MUST output all five before writing or running any test:
 - **Test name:** [descriptive name]
 - **Behavior under test:** [the observable behavior this verifies]
-- **Expected failure:** [the exact message of the first assertion that will fail, quoted. If the test has several assertions, order them so the first one is the behavior under test, or split the test. A RED on any other assertion is a misprediction.]
+- **Expected failure:** [the exact message of the assertion expected to fail first when the test runs red, quoted]
 - **Why this test first:** [why this is the most conditionally interesting test to write next, or for degenerate/zero cases, why this establishes the API before anything else]
 - **Stub check:** Could a no-op stub satisfy this test? If yes, name the next test that a stub cannot satisfy — write it next.
 
-Run the test. If actual failure ≠ expected failure — STOP. Diagnose the mismatch before writing any production code. A test that fails differently than predicted is testing the wrong thing, or is ordered so that a secondary assertion runs before the one that defines the behavior; fix whichever it is before continuing.
+Run the test. If actual failure ≠ expected failure — STOP. Diagnose before writing any production code. In fail-fast assertion styles, a mismatch means the test is testing the wrong thing, or the assertions are ordered so a secondary one runs before the one that expresses the behavior under test — reorder them or split the test. In styles that aggregate failures per test (`subTest`, soft assertions, `aggregate_failures`), check whether the predicted assertion is among those reported rather than whether it ran first; the same STOP applies only if it is absent. See `references/testing-anti-patterns.md` #9.
 
 **Test Sequencing**
 

--- a/2. Do/2. Test Drive the Change.md
+++ b/2. Do/2. Test Drive the Change.md
@@ -41,11 +41,11 @@ Try to add tests to existing fixtures where the tests fit coherently into the co
 YOU MUST output all five before writing or running any test:
 - **Test name:** [descriptive name]
 - **Behavior under test:** [the observable behavior this verifies]
-- **Expected failure:** [exact assertion message or error expected when the test runs red]
+- **Expected failure:** [the exact message of the first assertion that will fail, quoted. If the test has several assertions, order them so the first one is the behavior under test, or split the test. A RED on any other assertion is a misprediction.]
 - **Why this test first:** [why this is the most conditionally interesting test to write next, or for degenerate/zero cases, why this establishes the API before anything else]
 - **Stub check:** Could a no-op stub satisfy this test? If yes, name the next test that a stub cannot satisfy — write it next.
 
-Run the test. If actual failure ≠ expected failure — STOP. Diagnose the mismatch before writing any production code. A test that fails differently than predicted is testing the wrong thing.
+Run the test. If actual failure ≠ expected failure — STOP. Diagnose the mismatch before writing any production code. A test that fails differently than predicted is testing the wrong thing, or is ordered so that a secondary assertion runs before the one that defines the behavior; fix whichever it is before continuing.
 
 **Test Sequencing**
 

--- a/2. Do/Testing Anti-Patterns.md
+++ b/2. Do/Testing Anti-Patterns.md
@@ -90,6 +90,16 @@ Testing the first edited instance of a repeated assumption -- one step of a mult
 
 *This rule does not self-apply.* On the very next cycle after it was written, the identical pattern recurred twice more (a docs pass that fixed only the first mention of a stale claim, not the rest of the document; a stage file's own overview sentence left unconverted because it sat outside any labeled per-mode section) -- caught again only by a fresh adversarial pass, not by re-reading this list. Advisory text you wrote for yourself is not a gate; see the Check phase's Decision probe, which now requires an operator-chosen critic model rather than relying on the same session re-reading its own work.
 
+## 9. Loose Called Shot
+
+The called shot's "Expected failure" names the assertion that best expresses the behavior under test, rather than the assertion the test runner will actually report first when the test has several. The prediction and the RED are both individually reasonable; they just describe different lines.
+
+*Diagnosis:* A test carries more than one assertion, and the one chosen as "Expected failure" is not the first to execute. The test runner stops and reports at the first failing assertion, so RED fires there regardless of which assertion the called shot named.
+
+*Rule:* Predict the exact message of the first assertion that will fail, not the most meaningful one. If the assertion that defines the behavior is not first, either reorder the assertions so it is, or split the test so each assertion has its own called shot. A RED on any assertion other than the predicted one means the prediction was wrong, not that the test needs re-explaining.
+
+*Origin:* A test with eight assertions across two files predicted `toContain("Verification Log")` as the expected failure; the RED fired two lines earlier, on `expected.toLowerCase()).toContain(reviewer)`. Both phrases were genuinely absent, so the test was sound -- the prediction was simply about a different, later assertion than the one that ran. Twenty other called shots in the same session predicted correctly because each test happened to lead with its defining assertion; the one that did not was the one that misfired. See #155.
+
 ---
 
 ## Quick Check Before Committing

--- a/2. Do/Testing Anti-Patterns.md
+++ b/2. Do/Testing Anti-Patterns.md
@@ -90,13 +90,15 @@ Testing the first edited instance of a repeated assumption -- one step of a mult
 
 *This rule does not self-apply.* On the very next cycle after it was written, the identical pattern recurred twice more (a docs pass that fixed only the first mention of a stale claim, not the rest of the document; a stage file's own overview sentence left unconverted because it sat outside any labeled per-mode section) -- caught again only by a fresh adversarial pass, not by re-reading this list. Advisory text you wrote for yourself is not a gate; see the Check phase's Decision probe, which now requires an operator-chosen critic model rather than relying on the same session re-reading its own work.
 
+---
+
 ## 9. Loose Called Shot
 
 The called shot's "Expected failure" names the assertion that best expresses the behavior under test, rather than the assertion the test runner will actually report first when the test has several. The prediction and the RED are both individually reasonable; they just describe different lines.
 
-*Diagnosis:* A test carries more than one assertion, and the one chosen as "Expected failure" is not the first to execute. The test runner stops and reports at the first failing assertion, so RED fires there regardless of which assertion the called shot named.
+*Diagnosis:* A test carries more than one assertion, and the one chosen as "Expected failure" is not the first to execute. In fail-fast assertion styles, the runner stops at the first failing assertion, so RED fires there regardless of which assertion the called shot named. In styles that aggregate failures per test (`unittest.subTest`, soft assertions, `pytest-check`, RSpec's `aggregate_failures`), the runner instead reports every failing assertion together — there, the mismatch is the predicted assertion being absent from the report, not out of order.
 
-*Rule:* Predict the exact message of the first assertion that will fail, not the most meaningful one. If the assertion that defines the behavior is not first, either reorder the assertions so it is, or split the test so each assertion has its own called shot. A RED on any assertion other than the predicted one means the prediction was wrong, not that the test needs re-explaining.
+*Rule:* Predict the exact message of the first assertion that will fail, not the most meaningful one. If the assertion that defines the behavior is not first, either reorder the assertions so it is, or split the test so each assertion has its own called shot. A RED on any assertion other than the predicted one means the prediction was wrong, not that the test needs re-explaining. In aggregating styles, a RED naming several assertions including the predicted one is not a misprediction; only the predicted assertion's absence is.
 
 *Origin:* A test with eight assertions across two files predicted `toContain("Verification Log")` as the expected failure; the RED fired two lines earlier, on `expected.toLowerCase()).toContain(reviewer)`. Both phrases were genuinely absent, so the test was sound -- the prediction was simply about a different, later assertion than the one that ran. Twenty other called shots in the same session predicted correctly because each test happened to lead with its defining assertion; the one that did not was the one that misfired. See #155.
 
@@ -110,3 +112,4 @@ The called shot's "Expected failure" names the assertion that best expresses the
 - [ ] No production methods exist solely for test access
 - [ ] Every test watched fail before watching it pass
 - [ ] If the acceptance criteria makes a whole-flow/whole-file claim, a test exercises the complete thing -- not just the edited piece (see #8)
+- [ ] The called shot's "Expected failure" names the assertion that will actually run first, not just the most meaningful one (see #9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Called shot must predict the first-executing assertion, not the most meaningful one
+
+- **The DO master's CALLED SHOT block named "the exact assertion message or error expected" with
+  no anchor to *which* assertion, when a test carries several (#155).** In practice the prediction
+  drifts to the assertion that best expresses the behavior, while the test runner reports the
+  first one that executes. When those differ, a correct test's RED reads as a misprediction and
+  the STOP rule fires for the wrong reason — or worse, trains the operator to wave the mismatch
+  through, eroding the rule for the case it exists to catch. `Expected failure:` now asks for the
+  exact message of the first assertion that will fail, and names the fix directly: reorder the
+  assertions so the defining one runs first, or split the test.
+- **`Testing Anti-Patterns.md` gains item 9, "Loose Called Shot,"** naming the pattern so it is
+  citable in retros the way item 8 has been used as diagnostic vocabulary all cycle rather than
+  re-explained from scratch each time.
+- **`Human Working Agreements.md` gains the matching intervention question** — "Which assertion
+  did you predict, and which one fired?" — alongside the section's existing TDD-discipline
+  questions.
+- **Not verifiable by the eval harness, and said so rather than hidden.** The harness is
+  single-turn and never executes real code — the same structural limit #136 already found for
+  "Run the test." Whether a model predicted the actual first-executing assertion can only be
+  observed in real TDD work, not a synthetic scenario, so `rubric_2.py` and the scenario JSON are
+  deliberately untouched. Confirmed instead that the four labels `called_shot_required` matches on
+  (`Test name:`, `Behavior under test:`, `Expected failure:`, `Why this test first:`) are unchanged
+  — this edit only touches bracket-instruction text and the follow-up sentence, so the mechanical
+  tier's behavior across every scenario that uses it is unaffected.
 ### must_not_contain now matches case-insensitively (#116)
 
 - **`check_mechanical`'s `must_not_contain` matched case-sensitively, so `"all done"` missed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,29 @@
   drifts to the assertion that best expresses the behavior, while the test runner reports the
   first one that executes. When those differ, a correct test's RED reads as a misprediction and
   the STOP rule fires for the wrong reason — or worse, trains the operator to wave the mismatch
-  through, eroding the rule for the case it exists to catch. `Expected failure:` now asks for the
-  exact message of the first assertion that will fail, and names the fix directly: reorder the
-  assertions so the defining one runs first, or split the test.
+  through, eroding the rule for the case it exists to catch. `Expected failure:` now asks purely
+  for the assertion expected to fail first; the remedy (reorder the assertions or split the test)
+  moved out of the bracket and into the STOP sentence itself, next to the ordering guidance it's
+  paired with.
 - **`Testing Anti-Patterns.md` gains item 9, "Loose Called Shot,"** naming the pattern so it is
   citable in retros the way item 8 has been used as diagnostic vocabulary all cycle rather than
-  re-explained from scratch each time.
+  re-explained from scratch each time. Matches item 8's own layout: `---` separator, a Quick Check
+  line, and a cross-reference from the DO master at the point the guidance applies.
 - **`Human Working Agreements.md` gains the matching intervention question** — "Which assertion
   did you predict, and which one fired?" — alongside the section's existing TDD-discipline
   questions.
+- **Caught by an adversarial critic pass, per this cycle's own CHECK requirement: the first version
+  stated a false universal.** "The test runner stops and reports at the first failing assertion"
+  is true for fail-fast styles and false for styles that intentionally aggregate multiple
+  assertions per test — `unittest.subTest`, soft assertions, `pytest-check`, RSpec's
+  `aggregate_failures`. Under those, a legitimate RED report names several assertions together, and
+  "a RED on any other assertion is a misprediction" would falsely STOP the model — reintroducing,
+  for a different framework family, the exact bug #155 was filed to eliminate. Not hypothetical:
+  `skill/tests/test_build.py` uses `subTest` in several places written this same cycle. Both the DO
+  master and item 9 now qualify for aggregating styles: check whether the predicted assertion is
+  among those reported, not whether it ran first. The test that pinned item 9's heading alone
+  (passing against an empty section) was also caught the same way and now pins the Rule paragraph;
+  mutation-tested afterward to confirm it no longer passes vacuously.
 - **Not verifiable by the eval harness, and said so rather than hidden.** The harness is
   single-turn and never executes real code — the same structural limit #136 already found for
   "Run the test." Whether a model predicted the actual first-executing assertion can only be

--- a/Human Working Agreements.md
+++ b/Human Working Agreements.md
@@ -14,6 +14,7 @@
 - "Where's the failing test first?"
 - "You're fixing multiple things. Focus on one failing test?"
 - "This feels like scope creep. Are we still on step [N]?"
+- "Which assertion did you predict, and which one fired?"
 
 **You must:** Stop and answer the process question before continuing. Process discipline trumps immediate progress.
 

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -637,6 +637,16 @@ class TestSkillPackage(unittest.TestCase):
             "do-prompts.md doesn't contain expected master content",
         )
 
+    def test_do_prompts_contains_the_first_executing_assertion_language(self):
+        """#155's DO master edit must reach the packaged skill, not just the source.
+        Mirrors test_do_prompts_contains_master_content's pattern."""
+        packaged = read_zip_file(SKILL_FILE, f"{SKILL_NAME}/references/do-prompts.md")
+        self.assertIn(
+            "the first assertion that will fail",
+            packaged,
+            "do-prompts.md does not contain the #155 called-shot wording",
+        )
+
     def test_working_agreements_matches_master(self):
         packaged = read_zip_file(SKILL_FILE, f"{SKILL_NAME}/references/working-agreements.md")
         master = (REPO_ROOT / "Human Working Agreements.md").read_text()
@@ -818,6 +828,54 @@ class TestBuildScript(unittest.TestCase):
 
 class TestHookInfrastructure(unittest.TestCase):
     """Verify git hook infrastructure files exist and are correctly structured."""
+
+    def test_called_shot_requires_predicting_the_first_executing_assertion(self):
+        """#155: the called shot's 'Expected failure' field named the most meaningful
+        assertion in a multi-assertion test, not the one the runner reports first. When
+        those differ, a correct test's RED reads as a misprediction and the STOP rule
+        fires for the wrong reason -- or worse, trains the operator to wave it through,
+        which erodes the rule for the case it exists to catch.
+
+        Checked against the master source directly (unconditional, no build needed).
+        assertTrue rather than assertIn per #143.
+        """
+        master = (REPO_ROOT / "2. Do" / "2. Test Drive the Change.md").read_text()
+        self.assertTrue(
+            "the first assertion that will fail" in master,
+            "the DO master's CALLED SHOT block does not ask for the first-executing "
+            "assertion specifically, so a loose prediction against a different "
+            "assertion in the same test cannot be told apart from a genuine "
+            "misprediction (#155)",
+        )
+        self.assertTrue(
+            "ordered so that a secondary assertion runs before the one that defines "
+            "the behavior" in master,
+            "the DO master's STOP-rule sentence does not name assertion ordering as a "
+            "possible cause of a RED mismatch, only 'testing the wrong thing' (#155)",
+        )
+
+    def test_testing_anti_patterns_names_the_loose_called_shot_pattern(self):
+        """#155's own suggestion: name the pattern so it is citable in retros, the way
+        #8 (Partial-Instance Coverage) has been used as diagnostic vocabulary all
+        cycle rather than re-explained from scratch each time."""
+        master = (REPO_ROOT / "2. Do" / "Testing Anti-Patterns.md").read_text()
+        self.assertTrue(
+            "## 9. Loose Called Shot" in master,
+            "Testing Anti-Patterns.md has no item 9 for a called shot that predicts "
+            "the most meaningful assertion rather than the first-executing one (#155)",
+        )
+
+    def test_working_agreements_asks_which_assertion_fired(self):
+        """The operator-side half of #155: an intervention question matching the
+        format already used by every other line in this section, so 'the called shot
+        drifted' is as askable in the moment as 'where's the failing test first'."""
+        master = (REPO_ROOT / "Human Working Agreements.md").read_text()
+        self.assertTrue(
+            "Which assertion did you predict, and which one fired?" in master,
+            "Human Working Agreements.md's Process Discipline section has no "
+            "intervention question for a called shot that predicted the wrong "
+            "assertion (#155)",
+        )
 
     def test_working_agreements_requires_verifying_a_prior_commands_result(self):
         """#138: a command chain where one step fails silently must not let a later

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -642,7 +642,7 @@ class TestSkillPackage(unittest.TestCase):
         Mirrors test_do_prompts_contains_master_content's pattern."""
         packaged = read_zip_file(SKILL_FILE, f"{SKILL_NAME}/references/do-prompts.md")
         self.assertIn(
-            "the first assertion that will fail",
+            "the assertion expected to fail first",
             packaged,
             "do-prompts.md does not contain the #155 called-shot wording",
         )
@@ -841,28 +841,84 @@ class TestHookInfrastructure(unittest.TestCase):
         """
         master = (REPO_ROOT / "2. Do" / "2. Test Drive the Change.md").read_text()
         self.assertTrue(
-            "the first assertion that will fail" in master,
+            "the assertion expected to fail first" in master,
             "the DO master's CALLED SHOT block does not ask for the first-executing "
             "assertion specifically, so a loose prediction against a different "
             "assertion in the same test cannot be told apart from a genuine "
             "misprediction (#155)",
         )
         self.assertTrue(
-            "ordered so that a secondary assertion runs before the one that defines "
-            "the behavior" in master,
+            "ordered so a secondary one runs before the one that expresses the "
+            "behavior under test" in master,
             "the DO master's STOP-rule sentence does not name assertion ordering as a "
             "possible cause of a RED mismatch, only 'testing the wrong thing' (#155)",
+        )
+        self.assertTrue(
+            "aggregate failures per test" in master,
+            "the DO master's STOP-rule sentence has no qualification for assertion "
+            "styles that aggregate failures (subTest, soft assertions) -- for those, "
+            "'ran first' is the wrong question and the ordering-based rule above "
+            "would misfire on the repo's own subTest-based tests (found in adversarial "
+            "review of #155)",
         )
 
     def test_testing_anti_patterns_names_the_loose_called_shot_pattern(self):
         """#155's own suggestion: name the pattern so it is citable in retros, the way
         #8 (Partial-Instance Coverage) has been used as diagnostic vocabulary all
-        cycle rather than re-explained from scratch each time."""
+        cycle rather than re-explained from scratch each time.
+
+        Pins the Rule paragraph, not just the heading. An earlier version of this test
+        pinned only the heading and was found, by adversarial review, to pass against
+        an empty section -- mutation-tested afterward here to confirm it no longer does.
+        """
         master = (REPO_ROOT / "2. Do" / "Testing Anti-Patterns.md").read_text()
         self.assertTrue(
             "## 9. Loose Called Shot" in master,
             "Testing Anti-Patterns.md has no item 9 for a called shot that predicts "
             "the most meaningful assertion rather than the first-executing one (#155)",
+        )
+        self.assertTrue(
+            "Predict the exact message of the first assertion that will fail, not "
+            "the most meaningful one" in master,
+            "item 9's Rule paragraph is missing -- a heading alone does not tell "
+            "anyone what to do differently (#155)",
+        )
+        self.assertTrue(
+            "the mismatch is the predicted assertion being absent from the report, "
+            "not out of order" in master,
+            "item 9's Diagnosis does not qualify for assertion styles that aggregate "
+            "failures per test, so it states a false universal -- 'the runner stops "
+            "at the first failing assertion' is untrue for subTest, soft assertions, "
+            "and aggregate_failures, which this repo's own test suite uses (found in "
+            "adversarial review of #155)",
+        )
+
+    def test_testing_anti_patterns_item_9_matches_the_established_layout(self):
+        """Items 1-8 each open with a '---' separator and get a Quick Check line;
+        item 9 initially had neither, which is precisely item 8's own anti-pattern
+        (a document that indexes its items in several places, updated in only one)."""
+        master = (REPO_ROOT / "2. Do" / "Testing Anti-Patterns.md").read_text()
+        self.assertTrue(
+            "---\n\n## 9. Loose Called Shot" in master,
+            "item 9 has no '---' separator before it, unlike every other item in "
+            "this file (#155)",
+        )
+        self.assertTrue(
+            "(see #9)" in master,
+            "Quick Check Before Committing has no line referencing item 9, unlike "
+            "every other numbered item (#155)",
+        )
+
+    def test_do_master_cross_references_the_loose_called_shot_anti_pattern(self):
+        """Items 7 and 8 are both cross-referenced from the DO master at the exact
+        point their guidance applies (see '2. Do/2. Test Drive the Change.md:60,72,129').
+        Item 9 had no reference from anywhere outside its own section."""
+        master = (REPO_ROOT / "2. Do" / "2. Test Drive the Change.md").read_text()
+        self.assertTrue(
+            "references/testing-anti-patterns.md` #9" in master,
+            "the DO master's CALLED SHOT section does not cross-reference "
+            "testing-anti-patterns.md #9, unlike the #7 and #8 references elsewhere "
+            "in this same file (#155)",
         )
 
     def test_working_agreements_asks_which_assertion_fired(self):


### PR DESCRIPTION
Closes #155.

## The gap

The DO master's CALLED SHOT block asked for *"the exact assertion message or error expected when the test runs red"* with no anchor to **which** assertion, when a test carries several. In practice the prediction drifts to the assertion that best expresses the behavior under test, while the test runner reports the first one that executes. When those differ, a correct test's RED reads as a misprediction and the STOP rule fires for the wrong reason — or worse, trains the operator to wave the mismatch through, which erodes the rule for the case it exists to catch.

Reported from a real PDCA cycle on a downstream repo (full detail in #155): a test with eight assertions predicted `toContain("Verification Log")` as the expected failure; the RED fired two lines earlier, on a different assertion. Both phrases were genuinely absent — the test was sound, the prediction just named a later assertion than the one that ran.

## What ships

- **`Expected failure:`** now asks for the exact message of the **first** assertion that will fail, and states the fix directly in the field: reorder the assertions so the defining one runs first, or split the test.
- **`Testing Anti-Patterns.md` item 9, "Loose Called Shot"** — so the pattern is citable in retros the way item 8 has been used as diagnostic vocabulary all cycle rather than re-explained from scratch each time.
- **`Human Working Agreements.md`** gains the matching operator question: *"Which assertion did you predict, and which one fired?"*

## Not verifiable by the eval harness — said so rather than hidden

The harness is single-turn and never executes real code — the same structural limit #136 already found for "Run the test." Whether a model predicted the actual first-executing assertion can only be observed in real TDD work, not a synthetic scenario, so `rubric_2.py` and the scenario JSON are **deliberately untouched**. Three edits to that rubric were measured making scores worse this cycle (#149), and this change has no way to be measured as correct or incorrect by the harness regardless of edits.

## Mechanical safety, checked rather than assumed

`check_mechanical`'s `called_shot_required` matches on four literal labels: `Test name:`, `Behavior under test:`, `Expected failure:`, `Why this test first:`. Confirmed all four are present and unchanged — this edit only touches bracket-instruction text and the follow-up sentence, so the mechanical tier's behavior across every scenario using `called_shot_required` is unaffected.

## Testing

**RED first**, the called shot itself: `AssertionError: False is not true : the DO master's CALLED SHOT block does not ask for the first-executing assertion specifically...`

**Propagation confirmed with a real build, not inferred.** The new `do-prompts.md` test reads the packaged zip directly, mirroring the existing `test_do_prompts_contains_master_content` pattern. `test_working_agreements_matches_master` (pre-existing, full byte-equality) continues to pass since it's a generic equality check.

## Verification

```
250 passed, 216 subtests passed
Success: no issues found in 34 source files   (mypy)
All checks passed!                            (ruff)
CHANGELOG check passed (5 path(s) changed).
```

## Related

- #155 — this issue, filed with the proposed diff already drafted
- #138 — sibling working-agreement gap this session closed, same "verify before claiming" shape
- #136, #149 — why `rubric_2.py` stays untouched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_