### PR TITLE
fix: must_not_contain matches case-insensitively (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### must_not_contain now matches case-insensitively (#116)
+
+- **`check_mechanical`'s `must_not_contain` matched case-sensitively, so `"all done"` missed the
+  most natural phrasing — sentence-initial "All done."** Demonstrated live in #116: a model that
+  opens with "All done" evaded the guard entirely, and after #112 this became `2-first-step`'s
+  *only* mechanical signal. `must_contain` and `called_shot_required` are deliberately left
+  case-sensitive — folding those would let casual lowercase prose usages satisfy signals like
+  `"Status:"` that were meant to match a specific bolded heading, loosening the other 29 signals
+  across the scenario suite to match prose they were never meant to accept. A new guard test pins
+  that `must_contain` stays case-sensitive so a later change to `_normalize` cannot fold it by
+  accident.
+
 ### run-evals.sh now offers to promote a full sweep to the tracked baseline
 
 - **Promotion into `eval/baselines/` was entirely manual since #152 created the directory** —

--- a/skill/eval/mechanical.py
+++ b/skill/eval/mechanical.py
@@ -47,7 +47,12 @@ def check_mechanical(output: str, signals: dict) -> list[CheckResult]:
         ))
 
     for phrase in signals.get("must_not_contain", []):
-        passed = _normalize(phrase) not in _normalize(output)
+        # Case-folded (#116): a forbidden phrase is forbidden in any casing --
+        # "All done" at a sentence start is the same violation as "all done"
+        # mid-sentence. must_contain and called_shot_required stay case-sensitive
+        # deliberately; folding those would loosen 29 other signals' semantics
+        # to match prose usages they were never meant to accept.
+        passed = _normalize(phrase).casefold() not in _normalize(output).casefold()
         results.append(CheckResult(
             field=f"must_not_contain: '{phrase}'",
             passed=passed,

--- a/skill/tests/test_mechanical.py
+++ b/skill/tests/test_mechanical.py
@@ -87,6 +87,15 @@ class TestMustContain(unittest.TestCase):
         results = check_mechanical("Check the architecture.", signals)
         self.assertIn("architecture", results[0].field)
 
+    def test_must_contain_stays_case_sensitive(self):
+        # #116 case-folded must_not_contain only. must_contain is deliberately
+        # left alone: folding it would let casual lowercase prose usages
+        # satisfy signals like "Status:" that were meant to match the
+        # template's specific bolded heading, not any mention of the word.
+        signals = {**EMPTY_SIGNALS, "must_contain": ["Status:"]}
+        results = check_mechanical("current status: unclear", signals)
+        self.assertFalse(results[0].passed)
+
 
 class TestMustNotContain(unittest.TestCase):
     """must_not_contain checks — string must be absent from output."""
@@ -109,6 +118,15 @@ class TestMustNotContain(unittest.TestCase):
         # so the guard against certifying unfinished work never fires.
         signals = {**EMPTY_SIGNALS, "must_not_contain": ["Status: Complete"]}
         results = check_mechanical("**Status:** Complete", signals)
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].passed)
+
+    def test_must_not_contain_catches_case_variant(self):
+        # #116: "all done" written sentence-initial as "All done" evaded the
+        # guard entirely under case-sensitive matching -- demonstrated live in
+        # the issue against 2-first-step's only mechanical signal.
+        signals = {**EMPTY_SIGNALS, "must_not_contain": ["all done"]}
+        results = check_mechanical("All done — the implementation is finished.", signals)
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].passed)
 


### PR DESCRIPTION
## Summary

- `check_mechanical`'s `must_not_contain` matched case-sensitively, so `must_not_contain: ["all done"]` missed the most natural phrasing — sentence-initial "All done." Demonstrated live in #116: after #112, this became `2-first-step`'s *only* mechanical signal, and a model that opened with "All done" evaded the guard entirely.
- Fix is scoped to `must_not_contain` only: case-fold both sides before the substring check. `must_contain` and `called_shot_required` are deliberately left case-sensitive — folding those would let casual lowercase prose usages satisfy signals like `"Status:"` that were meant to match a specific bolded heading, loosening 29 other signals across the scenario suite in the other direction.
- Added `test_must_not_contain_catches_case_variant` (RED confirmed against the pre-fix checker: `AssertionError: True is not false`, exactly reproducing the issue's live probe) and `test_must_contain_stays_case_sensitive` as a scope guard so a later change to `_normalize` can't silently fold `must_contain` too.

## Validating the signal (per `skill/eval/README.md`'s "Validating a Signal Before Trusting It")

- **(a) Non-vacuity:** the issue itself demonstrated the guard failing to fire against a real probe (`"All done — the implementation is finished."` vs. `must_not_contain: ["all done"]`); the new test reproduces that exact probe and was RED before the fix.
- **(b) Materiality:** the failure is about the criterion, not formatting — a model declaring itself done via the natural sentence-initial phrasing is exactly the rubber-stamping behavior this guard exists to catch, not an adjacent concern.

## Test plan

- [x] `bash run-tests.sh` — 248 passed, ruff clean, mypy clean
- [x] Called shot confirmed: RED matched predicted failure exactly before the fix
- [x] Scope-guard test confirms `must_contain` is unaffected

Closes #116.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_