### PR TITLE
fix: revert PR #169's global case-fold — it regressed two live scenarios on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,29 @@
   (`Test name:`, `Behavior under test:`, `Expected failure:`, `Why this test first:`) are unchanged
   — this edit only touches bracket-instruction text and the follow-up sentence, so the mechanical
   tier's behavior across every scenario that uses it is unaffected.
-### must_not_contain now matches case-insensitively (#116)
 
-- **`check_mechanical`'s `must_not_contain` matched case-sensitively, so `"all done"` missed the
-  most natural phrasing — sentence-initial "All done."** Demonstrated live in #116: a model that
-  opens with "All done" evaded the guard entirely, and after #112 this became `2-first-step`'s
-  *only* mechanical signal. `must_contain` and `called_shot_required` are deliberately left
-  case-sensitive — folding those would let casual lowercase prose usages satisfy signals like
-  `"Status:"` that were meant to match a specific bolded heading, loosening the other 29 signals
-  across the scenario suite to match prose they were never meant to accept. A new guard test pins
-  that `must_contain` stays case-sensitive so a later change to `_normalize` cannot fold it by
-  accident.
+### The "all done" guard now catches sentence-initial capitalization (#116)
+
+- **`must_not_contain: ["all done"]` matched case-sensitively, so the most natural phrasing —
+  sentence-initial "All done" — evaded it entirely.** Demonstrated live in #116, and after #112
+  this became `2-first-step`'s *only* mechanical signal.
+- **First attempt case-folded `must_not_contain` globally in `eval/mechanical.py`. An adversarial
+  critic pass (operator-chosen model: Opus) found it broke two other scenarios on the same
+  branch.** `1a-vague-goal`'s `"Add an index"` and `4-tdd-breakdown`'s `"you should"` both rely on
+  capitalization to distinguish a directive statement from an incidental, compliant mention —
+  folding the whole signal type made both start matching lowercase prose they were never meant to
+  catch. Confirmed empirically: a compliant 1a response containing "...tell you to add an
+  index..." passed against `main` and failed against the folded version; likewise a compliant ACT
+  response containing "You should have the final call..." Reverted the code change entirely
+  (`eval/mechanical.py` and `tests/test_mechanical.py` are now byte-identical to `main`).
+- **Fixed at the data layer instead:** added the capitalized variant `"All done"` directly to the
+  three scenarios that actually need it (`2-first-step`, `2-beads-ordering-capture`,
+  `2-ponytail-precedence`) in `eval/scenarios/2_scenarios.json`, leaving every other
+  `must_not_contain` phrase's case-sensitivity untouched.
+  `test_all_done_guard_catches_sentence_initial_capitalization` in `tests/test_build.py` pins the
+  fix against the real scenario data (RED confirmed before the data edit, GREEN after), and the
+  two previously-broken compliant responses were re-verified to pass clean against the final
+  scenario file.
 
 ### run-evals.sh now offers to promote a full sweep to the tracked baseline
 

--- a/skill/eval/mechanical.py
+++ b/skill/eval/mechanical.py
@@ -47,12 +47,7 @@ def check_mechanical(output: str, signals: dict) -> list[CheckResult]:
         ))
 
     for phrase in signals.get("must_not_contain", []):
-        # Case-folded (#116): a forbidden phrase is forbidden in any casing --
-        # "All done" at a sentence start is the same violation as "all done"
-        # mid-sentence. must_contain and called_shot_required stay case-sensitive
-        # deliberately; folding those would loosen 29 other signals' semantics
-        # to match prose usages they were never meant to accept.
-        passed = _normalize(phrase).casefold() not in _normalize(output).casefold()
+        passed = _normalize(phrase) not in _normalize(output)
         results.append(CheckResult(
             field=f"must_not_contain: '{phrase}'",
             passed=passed,

--- a/skill/eval/scenarios/2_scenarios.json
+++ b/skill/eval/scenarios/2_scenarios.json
@@ -7,7 +7,8 @@
     "expected_signals": {
       "must_contain": [],
       "must_not_contain": [
-        "all done"
+        "all done",
+        "All done"
       ],
       "called_shot_required": false
     }
@@ -40,7 +41,8 @@
         "Reason:"
       ],
       "must_not_contain": [
-        "all done"
+        "all done",
+        "All done"
       ],
       "called_shot_required": false
     }
@@ -75,7 +77,8 @@
         "tests/test_http_headers.py"
       ],
       "must_not_contain": [
-        "all done"
+        "all done",
+        "All done"
       ],
       "called_shot_required": true
     }

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -305,6 +305,43 @@ class TestEvalScenarios(unittest.TestCase):
                         "as a pass forever",
                     )
 
+    def test_all_done_guard_catches_sentence_initial_capitalization(self):
+        """#116: "all done" missed the natural sentence-initial phrasing "All done."
+
+        Demonstrated live in the issue: a model opening a response with "All done"
+        evaded must_not_contain: ["all done"] entirely under case-sensitive matching,
+        and after #112 this is 2-first-step's *only* mechanical signal.
+
+        Fixed by adding the capitalized variant directly to the three affected
+        scenarios' forbidden-phrase lists -- not by case-folding must_not_contain
+        globally in eval/mechanical.py. A fresh adversarial critic pass on that
+        approach found it broke two *other* scenarios that rely on capitalization
+        to distinguish a directive statement from an incidental mention:
+        1a-vague-goal's "Add an index" and 4-tdd-breakdown's "you should" both
+        started matching compliant, lowercase incidental usage once must_not_contain
+        was folded suite-wide. Scoping the fix to the three scenarios that actually
+        need it leaves those two signals' case-sensitivity intact.
+        """
+        import json
+
+        from eval.mechanical import check_mechanical
+
+        scenarios = json.loads((EVAL_SCENARIOS_DIR / "2_scenarios.json").read_text())
+        affected = {"2-first-step", "2-beads-ordering-capture", "2-ponytail-precedence"}
+        targets = [s for s in scenarios if s["scenario_id"] in affected]
+        self.assertEqual(len(targets), 3, "expected all three #116-affected scenarios")
+        for scenario in targets:
+            with self.subTest(scenario=scenario["scenario_id"]):
+                results = check_mechanical(
+                    "All done — the implementation is finished.",
+                    scenario["expected_signals"],
+                )
+                mnc_results = [r for r in results if r.field.startswith("must_not_contain")]
+                self.assertTrue(
+                    any(not r.passed for r in mnc_results),
+                    f"{scenario['scenario_id']} did not flag sentence-initial 'All done'",
+                )
+
     def test_scenario_files_valid_against_schema(self):
         """All JSON files in eval/scenarios/ must pass validate_scenario.
         Passes vacuously until scenario files are added in Step 4."""

--- a/skill/tests/test_mechanical.py
+++ b/skill/tests/test_mechanical.py
@@ -87,15 +87,6 @@ class TestMustContain(unittest.TestCase):
         results = check_mechanical("Check the architecture.", signals)
         self.assertIn("architecture", results[0].field)
 
-    def test_must_contain_stays_case_sensitive(self):
-        # #116 case-folded must_not_contain only. must_contain is deliberately
-        # left alone: folding it would let casual lowercase prose usages
-        # satisfy signals like "Status:" that were meant to match the
-        # template's specific bolded heading, not any mention of the word.
-        signals = {**EMPTY_SIGNALS, "must_contain": ["Status:"]}
-        results = check_mechanical("current status: unclear", signals)
-        self.assertFalse(results[0].passed)
-
 
 class TestMustNotContain(unittest.TestCase):
     """must_not_contain checks — string must be absent from output."""
@@ -118,15 +109,6 @@ class TestMustNotContain(unittest.TestCase):
         # so the guard against certifying unfinished work never fires.
         signals = {**EMPTY_SIGNALS, "must_not_contain": ["Status: Complete"]}
         results = check_mechanical("**Status:** Complete", signals)
-        self.assertEqual(len(results), 1)
-        self.assertFalse(results[0].passed)
-
-    def test_must_not_contain_catches_case_variant(self):
-        # #116: "all done" written sentence-initial as "All done" evaded the
-        # guard entirely under case-sensitive matching -- demonstrated live in
-        # the issue against 2-first-step's only mechanical signal.
-        signals = {**EMPTY_SIGNALS, "must_not_contain": ["all done"]}
-        results = check_mechanical("All done — the implementation is finished.", signals)
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].passed)
 


### PR DESCRIPTION
## Why this exists

PR #169 (#116) merged at `5c77d07` — the **first** commit on that branch, before an adversarial critic pass (run as part of the same PR, per `3. Check/3. Completeness Check.md`) found and I fixed a real regression. The remediation commit (`fa6d310`) was pushed to that branch afterward, but the PR had already been merged and closed by the time it landed, so the fix never made it into `main`.

**Confirmed live on `main` right now:** `check_mechanical`'s global case-fold of `must_not_contain` breaks two existing, intentionally case-sensitive guards:

```
1a-vague-goal (against current main): must_not_contain 'Add an index' -> False (guard incorrectly fires)
4-tdd-breakdown (against current main): must_not_contain 'you should'  -> False (guard incorrectly fires)
```

Both scenarios' compliant example responses (a clarifying question containing lowercase "add an index"; a sentence-initial "You should have the final call...") now falsely trip guards that were designed to catch *directive*, capitalized prescriptive language, not incidental lowercase mentions. This is exactly the false-positive the critic pass demonstrated before #169 merged — it just merged anyway, ahead of the fix.

## What this PR does

Cherry-picks `fa6d310` (the already-written, already-tested remediation) onto current `main`:

- Reverts `eval/mechanical.py` and `tests/test_mechanical.py` to be **byte-identical to `main`** (confirmed via diff) — the global case-fold is fully undone.
- Fixes the original #116 bug at the data layer instead: adds the capitalized `"All done"` variant directly to the three scenarios that actually need it (`2-first-step`, `2-beads-ordering-capture`, `2-ponytail-precedence`) in `eval/scenarios/2_scenarios.json`, leaving every other `must_not_contain` phrase's case-sensitivity untouched.
- `test_all_done_guard_catches_sentence_initial_capitalization` in `tests/test_build.py` pins the fix against the real scenario data.

## Test plan

- [x] `bash run-tests.sh` on top of current `main` — 253 passed, 219 subtests, ruff clean, mypy clean
- [x] `eval/mechanical.py` / `tests/test_mechanical.py` confirmed byte-identical to the pre-#116 baseline
- [x] Re-verified both previously-broken compliant responses (`1a-vague-goal`, `4-tdd-breakdown`) now pass clean against this branch

Full history of how the regression was found and fixed is on PR #169's comment thread.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_