### PR TITLE
Guard testing-anti-patterns.md propagation and record rubric-ladder version in eval reports (#167, #172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### `testing-anti-patterns.md` now has a propagation test (#167)
+
+- `do-prompts.md`, `check-prompts.md`, `act-prompts.md`, and `working-agreements.md` all
+  had a test guarding that `build.py` actually copies their master source content into the
+  packaged skill. `testing-anti-patterns.md` had none — nothing would have failed if
+  `build.py` silently stopped copying it, or copied stale content.
+- Added `test_testing_anti_patterns_matches_master`, asserting exact equality between the
+  packaged file and `2. Do/Testing Anti-Patterns.md` — stronger than a substring pin since
+  this file is copied verbatim (`COPIED_FROM_MASTER`, no license stripping, no injections),
+  so equality catches truncation or staleness anywhere in the file, not just around one item.
+- Mutation-tested before trusting it: temporarily pointed `COPIED_FROM_MASTER` at the wrong
+  master file, confirmed the new test fails, then reverted and confirmed it passes again.
+
 ### `2-superpowers-tdd-precedence` scoped to `called-shot` instead of skipping GEval entirely (#136, #148)
 
 - **#148's mechanism landed with nothing using it.** The scoping infrastructure (per-scenario

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Eval reports now record which rubric-ladder version produced them (#172)
+
+- No report could previously tell a reader whether it was produced by the same rubric
+  text as another report. #153 added a scoring band to all five rubrics; #148 rewrote
+  the shared bands and scaffold again. Either shift moves scores by construction wherever
+  a response lands in the newly affected range, so a GEval delta measured across such a
+  change was easy to misattribute to a prompt regression rather than the instrument.
+- Every report now carries a `**Rubric ladder:**` line — a 12-character sha256
+  fingerprint of all five rubrics' assembled `CRITERIA` text (`eval/reporter.py`'s new
+  `rubric_ladder_fingerprint`), right after the existing `**Environment:**`
+  (deepeval/anthropic version) line. Same "before the results" placement rationale as
+  #145's mechanism, which this directly extends.
+- `eval/baselines/README.md` updated to describe reading the new line: two reports with
+  matching fingerprints are safely comparable; a report from before this line existed
+  (e.g. `report_20260909_174245.md`) carries none, so the fingerprint can only rule
+  reports *in*, never rule an unfingerprinted one out.
+- **Second gap #172 named:** validation evidence for a rubric/prompt PR was previously
+  citable only by a GitHub Actions run ID or job log — both subject to retention and
+  eventually stop resolving (this branch's own #136 controlled A/B validation, cited only
+  by CI run ID two commits ago, is exactly this pattern). `CLAUDE.md`'s "Validating Prompt
+  Changes" gained a new step 5: save the justifying run under `eval/results/` (or promote
+  it to `eval/baselines/`) and reference it by filename, not only by run ID.
+
 ### `testing-anti-patterns.md` now has a propagation test (#167)
 
 - `do-prompts.md`, `check-prompts.md`, `act-prompts.md`, and `working-agreements.md` all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,12 @@ Any edit to master prompt files or eval rubrics requires:
 2. Make one discrete change, rebuild (`bash skill/build-skill.sh`)
 3. Re-run only the affected phase evals
 4. All previously passing scenarios must still pass — see `skill/SUPERVISION-PROTOCOL.md` for the full table of phase → eval class mappings
+5. **Save the run that justifies the change, don't just cite it.** A validation run
+   dispatched specifically to support a rubric/prompt PR should be saved under
+   `skill/eval/results/` (or promoted to `skill/eval/baselines/`) and referenced by
+   filename in the PR/CHANGELOG — not only by a GitHub Actions run ID or job log, which
+   are subject to retention and eventually stop resolving (#172). A CI run ID is fine as
+   a pointer to *where the numbers came from*; it is not durable evidence on its own.
 
 **Read the baseline's caveats before comparing against it.** Each baseline records the
 `deepeval` and `anthropic` versions that produced it, and scores are not comparable across

--- a/skill/eval/baselines/README.md
+++ b/skill/eval/baselines/README.md
@@ -54,15 +54,18 @@ to appear in some baseline here.
 dependency bump, and a report without that line predates the mechanism — treat its numbers
 as unattributable, which is precisely why #122 could not be answered in retrospect.
 
-**The rubric ladder itself is a version, and nothing records it.** #153 added a `0.6 —
-Borderline` band to all five rubrics, between the pre-existing `0.7` and `0.4` bands. That
-shifts scores upward by construction wherever a response lands in the newly-populated
-0.5–0.6 region — the fix is meant to, that's the point — so a GEval delta measured against
-`report_20260909_174245.md` (which predates #153) is not evidence of a prompt regression or
-improvement; it may just be the ladder. No report currently records which rubric-ladder
-version produced it. Until that's tracked (#172), treat any GEval comparison spanning #153
-the same way as a dependency-bump comparison above: don't trust it without independently
-checking which ladder each side used.
+**The rubric ladder itself is a version — check the `**Rubric ladder:**` line (#172).**
+#153 added a `0.6 — Borderline` band to all five rubrics; #148 later rewrote the shared
+bands and scaffold again. Either change shifts scores by construction wherever a response
+lands in the newly affected range — the fix is meant to, that's the point — so a GEval
+delta measured across such a change is not evidence of a prompt regression or improvement
+by itself. Every report now records a short content fingerprint of all five rubrics'
+assembled `CRITERIA` text; two reports with different fingerprints used different rubric
+wording, whatever their timestamps say. A report from before this line existed (e.g.
+`report_20260909_174245.md`, which predates both #153 and #172) carries no fingerprint at
+all — treat a comparison against it the same way as a dependency-bump comparison above:
+the fingerprint can only rule two reports *in* as comparable, never rule an unfingerprinted
+one out.
 
 **Mechanical checks are the reliable gate.** They were steady across every measured run
 (17/18, 22/23, 17/18 on the #136 diagnostic).

--- a/skill/eval/reporter.py
+++ b/skill/eval/reporter.py
@@ -1,5 +1,6 @@
 """EvalReporter: collects scenario results and writes a Markdown report."""
 
+import hashlib
 import importlib.metadata
 import textwrap
 from pathlib import Path
@@ -9,6 +10,29 @@ from pathlib import Path
 # scoring, and the question was unanswerable because every report on record carried a
 # timestamp and nothing else. No run could be attributed to a version.
 PROVENANCE_PACKAGES = ("deepeval", "anthropic")
+
+
+def rubric_ladder_fingerprint(criteria_by_id: dict[str, str]) -> str:
+    """Short, deterministic fingerprint of a set of rubric CRITERIA strings (#172).
+
+    A rubric's bands and scaffold are a version, same as a dependency, but nothing
+    recorded which version produced a given report. #153 added a scoring band to all
+    five rubrics; #148 rewrote the shared bands and scaffold again. Either shifts scores
+    by construction wherever a response lands in the newly affected range, so a GEval
+    delta measured across such a change is not evidence of a prompt regression or
+    improvement by itself -- see eval/baselines/README.md. A fingerprint lets a reader
+    tell whether two reports share a rubric-ladder version without re-deriving it.
+
+    A content hash rather than a git commit reference: a commit reference is fragile
+    under shallow clones and squash merges, and it couples report generation to git
+    state. This needs neither.
+
+    Sorted by id and joined with an explicit separator between id and text -- an
+    unseparated join lets {"1a": "X"} and {"1": "aX"} collide ("1a" + "X" ==
+    "1" + "aX") despite different content.
+    """
+    combined = "\n".join(f"{rid}:{criteria_by_id[rid]}" for rid in sorted(criteria_by_id))
+    return hashlib.sha256(combined.encode()).hexdigest()[:12]
 
 
 def _installed_version(package: str) -> str:
@@ -83,6 +107,11 @@ class EvalReporter:
         # the scores below are comparable to the ones they are comparing them against.
         versions = ", ".join(f"{p}: {_installed_version(p)}" for p in PROVENANCE_PACKAGES)
         lines.append(f"**Environment:** {versions}\n")
+
+        from eval.rubrics import RUBRICS
+
+        ladder = rubric_ladder_fingerprint({rid: mod.CRITERIA for rid, mod in RUBRICS.items()})
+        lines.append(f"**Rubric ladder:** {ladder}\n")
 
         # Summary table
         lines.append("## Summary\n")

--- a/skill/tests/test_build.py
+++ b/skill/tests/test_build.py
@@ -710,6 +710,27 @@ class TestSkillPackage(unittest.TestCase):
             "working-agreements.md content doesn't match license-stripped master source",
         )
 
+    def test_testing_anti_patterns_matches_master(self):
+        """#167: nothing previously asserted that build.py copies
+        "2. Do/Testing Anti-Patterns.md" into the packaged skill at all -- unlike
+        do-prompts.md, check-prompts.md, act-prompts.md, and working-agreements.md, which
+        all have a propagation test. build.py's own COPIED_FROM_MASTER comment says this
+        file is copied verbatim, not license-stripped, so exact equality (not a substring
+        pin) is the right guard -- it fails on truncation or staleness anywhere in the
+        file, not just around one item, and needs no update when the master's content
+        changes shape.
+
+        Mirrors test_working_agreements_matches_master's pattern, without the license
+        split that file's master needs and this one's does not.
+        """
+        packaged = read_zip_file(SKILL_FILE, f"{SKILL_NAME}/references/testing-anti-patterns.md")
+        master = (REPO_ROOT / "2. Do" / "Testing Anti-Patterns.md").read_text()
+        self.assertEqual(
+            packaged.strip(),
+            master.strip(),
+            "testing-anti-patterns.md content doesn't match its master source",
+        )
+
     def test_addon_files_match_source(self):
         """Addon files in package should match their source files exactly."""
         for slug, files in ADDON_SOURCE_FILES.items():

--- a/skill/tests/test_evals_reporter.py
+++ b/skill/tests/test_evals_reporter.py
@@ -1,7 +1,7 @@
 """Unit tests for eval.reporter — no API calls, no pytest markers."""
 
 from eval.mechanical import CheckResult
-from eval.reporter import EvalReporter
+from eval.reporter import EvalReporter, rubric_ladder_fingerprint
 
 
 def _make_result(
@@ -327,6 +327,68 @@ class TestReportProvenance:
         '5 shot(s); 5 did not pass'."""
         content = EvalReporter().write_report(tmp_path / "empty.md").read_text()
         assert "deepeval" in content
+
+
+class TestRubricLadderFingerprint:
+    """A report must record which rubric-ladder version produced it (#172).
+
+    #153 added a new scoring band to all five rubrics; #148 rewrote the shared bands and
+    scaffold again. Either change moves scores upward or downward by construction wherever
+    a response lands in the newly affected range, so a GEval delta measured across such a
+    change is not evidence of a prompt regression or improvement on its own --
+    eval/baselines/README.md already warns about this, but nothing let a reader tell FROM
+    THE REPORT ITSELF whether two reports were produced by the same rubric text.
+
+    A content hash, not a git commit reference: a commit reference is fragile under
+    shallow clones and squash merges, and it couples report generation to git state. A
+    hash needs neither and answers the actual question -- did the ladder change between
+    these two reports -- directly.
+    """
+
+    def test_identical_criteria_produce_identical_fingerprint(self):
+        a = {"1a": "same text", "2": "other text"}
+        b = {"1a": "same text", "2": "other text"}
+        assert rubric_ladder_fingerprint(a) == rubric_ladder_fingerprint(b)
+
+    def test_changed_criteria_produce_a_different_fingerprint(self):
+        a = {"1a": "same text", "2": "other text"}
+        b = {"1a": "same text", "2": "DIFFERENT text"}
+        assert rubric_ladder_fingerprint(a) != rubric_ladder_fingerprint(b)
+
+    def test_fingerprint_is_independent_of_mapping_insertion_order(self):
+        """Two reports built from the same rubric content must fingerprint identically
+        regardless of dict iteration order, or an unrelated refactor of RUBRICS' literal
+        ordering would look like a rubric change."""
+        a = {"1a": "x", "2": "y"}
+        b = {"2": "y", "1a": "x"}
+        assert rubric_ladder_fingerprint(a) == rubric_ladder_fingerprint(b)
+
+    def test_id_and_text_do_not_collide_across_the_boundary(self):
+        """Concatenating rubric id and text with no separator lets {"1a": "X"} and
+        {"1": "aX"} hash identically despite different content ("1a" + "X" == "1" + "aX").
+        Catches that specific naive-join regression, not collisions in general."""
+        a = {"1a": "X"}
+        b = {"1": "aX"}
+        assert rubric_ladder_fingerprint(a) != rubric_ladder_fingerprint(b)
+
+
+class TestReportRecordsRubricLadder:
+    """Wiring check: the rendered report actually carries the fingerprint, computed from
+    the real rubrics, not just the pure function in isolation."""
+
+    def _report_text(self, tmp_path):
+        reporter = EvalReporter()
+        reporter.add(_make_result())
+        return reporter.write_report(tmp_path / "report.md").read_text()
+
+    def test_report_contains_a_rubric_ladder_line(self, tmp_path):
+        assert "**Rubric ladder:**" in self._report_text(tmp_path)
+
+    def test_recorded_fingerprint_matches_the_real_rubrics(self, tmp_path):
+        from eval.rubrics import RUBRICS
+
+        expected = rubric_ladder_fingerprint({rid: mod.CRITERIA for rid, mod in RUBRICS.items()})
+        assert f"**Rubric ladder:** {expected}" in self._report_text(tmp_path)
 
 
 class TestDivergenceNote:


### PR DESCRIPTION
## Summary

Two small, independent PDCA-cycled fixes from backlog triage, each following this repo's own TDD discipline (RED confirmed before the fix, mutation-tested where the underlying behavior was already correct).

### #167 — `testing-anti-patterns.md` had no propagation test

`do-prompts.md`, `check-prompts.md`, `act-prompts.md`, and `working-agreements.md` all had a test asserting `build.py` actually copies their master source into the packaged skill. `testing-anti-patterns.md` had none — nothing would fail if `build.py` silently stopped copying it, or copied stale content.

- Added `test_testing_anti_patterns_matches_master`: exact equality against the master (not a substring pin), since this file is copied verbatim (`COPIED_FROM_MASTER`, no stripping, no injections). Equality catches truncation or staleness anywhere in the file, not just around one item.
- Mutation-tested before trusting it: temporarily pointed `COPIED_FROM_MASTER` at the wrong master file, confirmed the new test fails, reverted, confirmed it passes again.

### #172 — eval reports didn't record which rubric-ladder version produced them, and validation evidence was only citable by CI run ID

- No report could tell a reader whether it shared rubric text with another report. #153 added a scoring band to all five rubrics; #148 rewrote the shared bands and scaffold again — either shifts scores by construction wherever a response lands in the newly affected range, so a GEval delta across such a change was easy to misattribute to a prompt regression rather than the instrument.
- Every report now carries a `**Rubric ladder:**` line — a 12-char sha256 fingerprint of all five rubrics' assembled `CRITERIA` text (`rubric_ladder_fingerprint` in `eval/reporter.py`), right after the existing `**Environment:**` line (#145), which this directly extends.
- `eval/baselines/README.md` updated to explain reading the new line: matching fingerprints mean two reports are safely comparable; an unfingerprinted report (predating this change) can only be excluded from that guarantee, never included by assumption.
- Second gap #172 named: validation evidence was previously citable only by a GitHub Actions run ID or job log, both subject to retention. `CLAUDE.md`'s "Validating Prompt Changes" gained a new step 5 — save the justifying run under `eval/results/` (or promote it to `eval/baselines/`) and reference it by filename. (Honest note: this branch's own prior PR (#174) cited its #136 A/B validation only by CI run ID — exactly the pattern this step now asks future work not to repeat. Not backfilled here, since doing so would mean either a fresh paid eval run or fetching a CI artifact this environment's egress proxy blocks.)

## Test plan

- [x] `cd skill && bash run-tests.sh` — 282 passed, 244 subtests
- [x] `ruff check .` / `mypy eval tests` clean
- [x] RED confirmed for #172 (`ImportError` before `rubric_ladder_fingerprint` existed) and mutation-confirmed for #167 (temporarily broke the copy mapping, watched the new test fail, reverted)
- [x] No eval API spend required — both fixes are structural/mechanical, no rubric or prompt content changed

Closes #167
Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQhYV8M4KgMZQSEWApzMZx)_